### PR TITLE
Update Boreas landing copy, layout, and navigation flow

### DIFF
--- a/app/actions/diagnostic.shared.ts
+++ b/app/actions/diagnostic.shared.ts
@@ -61,10 +61,10 @@ export const leadVolumeOptions: Array<{
   value: LeadVolumeBand;
   label: string;
 }> = [
-  { value: "1-20", label: "1 a 20 leads al mes" },
-  { value: "21-60", label: "21 a 60 leads al mes" },
-  { value: "61-150", label: "61 a 150 leads al mes" },
-  { value: "151-plus", label: "Más de 150 leads al mes" },
+  { value: "1-20", label: "1 a 20 contactos al mes" },
+  { value: "21-60", label: "21 a 60 contactos al mes" },
+  { value: "61-150", label: "61 a 150 contactos al mes" },
+  { value: "151-plus", label: "Más de 150 contactos al mes" },
 ];
 
 export const responseTimeOptions: Array<{
@@ -84,7 +84,7 @@ export const bookingFlowOptions: Array<{
   { value: "manual", label: "Manual, entre mensajes y llamadas" },
   { value: "whatsapp", label: "Principalmente por WhatsApp" },
   { value: "crm", label: "Con CRM o agenda digital" },
-  { value: "mixed", label: "Mixto, con varios hand-offs" },
+  { value: "mixed", label: "Mixto, con varios pasos manuales" },
 ];
 
 export function isDiagnosticVertical(value: string): value is DiagnosticVertical {

--- a/app/actions/diagnostic.shared.ts
+++ b/app/actions/diagnostic.shared.ts
@@ -1,0 +1,104 @@
+export type DiagnosticVertical = "salud" | "belleza" | "inmobiliario";
+export type LeadVolumeBand = "1-20" | "21-60" | "61-150" | "151-plus";
+export type ResponseTimeBand = "lt-5m" | "5-30m" | "30-120m" | "gt-2h";
+export type BookingFlowBand = "manual" | "whatsapp" | "crm" | "mixed";
+export type DiagnosticFocus = "speed-to-lead" | "qualification" | "agenda-automation" | "follow-up";
+export type DiagnosticPriority = "alta" | "media";
+
+export type DiagnosticSubmission = {
+  vertical: DiagnosticVertical;
+  leadVolume: LeadVolumeBand;
+  responseTime: ResponseTimeBand;
+  bookingFlow: BookingFlowBand;
+  source: string;
+};
+
+export type DiagnosticRecommendation = {
+  resultKey: string;
+  focus: DiagnosticFocus;
+  focusLabel: string;
+  priority: DiagnosticPriority;
+  headline: string;
+  summary: string;
+  playbookTitle: string;
+  nextSteps: [string, string, string];
+};
+
+export type DiagnosticActionState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  submitted?: DiagnosticSubmission;
+  recommendation?: DiagnosticRecommendation;
+};
+
+export const initialDiagnosticActionState: DiagnosticActionState = {
+  status: "idle",
+};
+
+export const verticalOptions: Array<{
+  value: DiagnosticVertical;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "salud",
+    label: "Salud",
+    hint: "Clínicas, consultorios, medspa y atención especializada.",
+  },
+  {
+    value: "belleza",
+    label: "Belleza",
+    hint: "Estéticas, salones, wellness y servicios con agenda activa.",
+  },
+  {
+    value: "inmobiliario",
+    label: "Inmobiliario",
+    hint: "Desarrollos, brokers y equipos que convierten visitas en cierres.",
+  },
+];
+
+export const leadVolumeOptions: Array<{
+  value: LeadVolumeBand;
+  label: string;
+}> = [
+  { value: "1-20", label: "1 a 20 leads al mes" },
+  { value: "21-60", label: "21 a 60 leads al mes" },
+  { value: "61-150", label: "61 a 150 leads al mes" },
+  { value: "151-plus", label: "Más de 150 leads al mes" },
+];
+
+export const responseTimeOptions: Array<{
+  value: ResponseTimeBand;
+  label: string;
+}> = [
+  { value: "lt-5m", label: "Menos de 5 minutos" },
+  { value: "5-30m", label: "Entre 5 y 30 minutos" },
+  { value: "30-120m", label: "Entre 30 minutos y 2 horas" },
+  { value: "gt-2h", label: "Más de 2 horas" },
+];
+
+export const bookingFlowOptions: Array<{
+  value: BookingFlowBand;
+  label: string;
+}> = [
+  { value: "manual", label: "Manual, entre mensajes y llamadas" },
+  { value: "whatsapp", label: "Principalmente por WhatsApp" },
+  { value: "crm", label: "Con CRM o agenda digital" },
+  { value: "mixed", label: "Mixto, con varios hand-offs" },
+];
+
+export function isDiagnosticVertical(value: string): value is DiagnosticVertical {
+  return verticalOptions.some((option) => option.value === value);
+}
+
+export function isLeadVolumeBand(value: string): value is LeadVolumeBand {
+  return leadVolumeOptions.some((option) => option.value === value);
+}
+
+export function isResponseTimeBand(value: string): value is ResponseTimeBand {
+  return responseTimeOptions.some((option) => option.value === value);
+}
+
+export function isBookingFlowBand(value: string): value is BookingFlowBand {
+  return bookingFlowOptions.some((option) => option.value === value);
+}

--- a/app/actions/diagnostic.ts
+++ b/app/actions/diagnostic.ts
@@ -17,10 +17,10 @@ import {
 } from "@/app/actions/diagnostic.shared";
 
 const focusLabels: Record<DiagnosticFocus, string> = {
-  "speed-to-lead": "Velocidad de respuesta",
-  qualification: "Calificación de intención",
-  "agenda-automation": "Agenda y hand-off operativo",
-  "follow-up": "Seguimiento consistente",
+  "speed-to-lead": "responder más rápido",
+  qualification: "entender mejor a cada contacto",
+  "agenda-automation": "hacer más fácil la cita o visita",
+  "follow-up": "dar seguimiento sin soltar conversaciones",
 };
 
 const leadVolumeScore: Record<LeadVolumeBand, number> = {
@@ -46,22 +46,22 @@ const bookingFlowScore: Record<BookingFlowBand, number> = {
 
 const playbookTitles: Record<DiagnosticVertical, Record<DiagnosticFocus, string>> = {
   salud: {
-    "speed-to-lead": "Playbook de triage inmediato y agenda clínica",
-    qualification: "Playbook de calificación clínica previa a la cita",
-    "agenda-automation": "Playbook de agenda, confirmación y pre-consulta",
-    "follow-up": "Playbook de recordatorios y reactivación de pacientes",
+    "speed-to-lead": "Responder rápido y proponer consulta",
+    qualification: "Entender el caso antes de agendar",
+    "agenda-automation": "Proponer horario y confirmar",
+    "follow-up": "Recordar y volver a contactar",
   },
   belleza: {
-    "speed-to-lead": "Playbook de respuesta inmediata y disponibilidad",
-    qualification: "Playbook de calificación de servicio ideal y ticket",
-    "agenda-automation": "Playbook de reserva, confirmación y no-shows",
-    "follow-up": "Playbook de seguimiento post-servicio y recompra",
+    "speed-to-lead": "Responder rápido y mostrar horarios",
+    qualification: "Entender el servicio ideal",
+    "agenda-automation": "Reservar y confirmar",
+    "follow-up": "Retomar y volver a vender",
   },
   inmobiliario: {
-    "speed-to-lead": "Playbook de respuesta inmediata y visita priorizada",
-    qualification: "Playbook de presupuesto, zona e intención de compra",
-    "agenda-automation": "Playbook de agenda de visitas y hand-off comercial",
-    "follow-up": "Playbook de seguimiento entre visita, objeciones y cierre",
+    "speed-to-lead": "Responder rápido y mover a visita",
+    qualification: "Entender presupuesto, zona e interés real",
+    "agenda-automation": "Proponer visita y ordenar agenda",
+    "follow-up": "Dar seguimiento después de la visita",
   },
 };
 
@@ -134,7 +134,7 @@ function buildRecommendation(submission: DiagnosticSubmission): DiagnosticRecomm
     focus,
     focusLabel,
     priority,
-    headline: `Tu palanca principal hoy es ${focusLabel.toLowerCase()}.`,
+    headline: `Hoy lo más importante es ${focusLabel}.`,
     summary: buildSummary(submission, verticalLabel, focus),
     playbookTitle: playbookTitles[submission.vertical][focus],
     nextSteps: buildNextSteps(submission, focus),
@@ -173,13 +173,13 @@ function buildSummary(
 ): string {
   const focusCopy: Record<DiagnosticFocus, string> = {
     "speed-to-lead":
-      "La intención ya existe, pero se enfría antes de que el equipo la convierta en acción.",
+      "La intención ya existe, pero se enfría antes de que alguien la atienda bien.",
     qualification:
-      "Responder rápido no basta: hace falta filtrar intención, urgencia y contexto antes de pasar al equipo.",
+      "Responder rápido ayuda, pero hace falta entender mejor qué busca cada persona.",
     "agenda-automation":
-      "La fuga está en los hand-offs, la disponibilidad y la coordinación operativa para cerrar la siguiente acción.",
+      "El problema está entre los mensajes, la agenda y todo lo que pasa antes de cerrar una cita o visita.",
     "follow-up":
-      "El problema no es solo la primera respuesta, sino la constancia para empujar al lead hasta una cita real.",
+      "No basta con contestar una vez; hace falta seguir la conversación hasta que avance.",
   };
 
   const verticalContext: Record<DiagnosticVertical, string> = {
@@ -191,7 +191,14 @@ function buildSummary(
       "En inmobiliario, la conversación necesita identificar intención y preparar la visita correcta sin desperdiciar tiempo comercial.",
   };
 
-  return `${focusCopy[focus]} ${verticalContext[submission.vertical]} Para ${verticalLabel}, el primer despliegue de Relevo debería enfocarse en ese cuello de botella antes de expandirse a otros módulos.`;
+  return `${focusCopy[focus]} ${verticalContext[submission.vertical]} Para ${verticalLabel}, esto sería lo primero que convendría ordenar con Relevo.`;
+}
+
+function getFirstStepLabel(
+  submission: DiagnosticSubmission,
+  focus: DiagnosticFocus,
+): string {
+  return `Empezar por ${playbookTitles[submission.vertical][focus].toLowerCase()}.`;
 }
 
 function buildNextSteps(
@@ -200,29 +207,29 @@ function buildNextSteps(
 ): [string, string, string] {
   const speedSla =
     submission.responseTime === "gt-2h" || submission.responseTime === "30-120m"
-      ? "Definir un SLA objetivo de respuesta menor a 5 minutos para nuevos leads."
-      : "Blindar el SLA actual para que no dependa de disponibilidad manual del equipo.";
+      ? "Buscar que las conversaciones nuevas reciban respuesta en menos de 5 minutos."
+      : "Cuidar el tiempo de respuesta para que no dependa de quién esté disponible.";
 
   const focusSteps: Record<DiagnosticFocus, [string, string, string]> = {
     "speed-to-lead": [
       speedSla,
-      `Diseñar primero el ${playbookTitles[submission.vertical]["speed-to-lead"].toLowerCase()}.`,
-      "Cerrar el hand-off con agenda o siguiente acción concreta antes de terminar la conversación.",
+      getFirstStepLabel(submission, "speed-to-lead"),
+      "Cerrar cada conversación con una cita, llamada o siguiente paso claro.",
     ],
     qualification: [
-      "Definir 3 a 5 datos obligatorios que separen curiosidad de intención real.",
-      `Diseñar primero el ${playbookTitles[submission.vertical].qualification.toLowerCase()}.`,
-      "Pasar al equipo solo leads con contexto suficiente para avanzar sin retrabajo.",
+      "Definir qué datos mínimos hacen falta para saber si la persona realmente quiere avanzar.",
+      getFirstStepLabel(submission, "qualification"),
+      "Pasar al equipo solo conversaciones con contexto suficiente para seguir sin perder tiempo.",
     ],
     "agenda-automation": [
-      "Centralizar disponibilidad, reglas de agenda y confirmaciones en un solo flujo.",
-      `Diseñar primero el ${playbookTitles[submission.vertical]["agenda-automation"].toLowerCase()}.`,
-      "Eliminar pasos manuales entre interés, propuesta de horario y confirmación final.",
+      "Tener disponibilidad, reglas de agenda y confirmaciones en un flujo mucho más claro.",
+      getFirstStepLabel(submission, "agenda-automation"),
+      "Quitar pasos manuales entre el interés inicial y la confirmación final.",
     ],
     "follow-up": [
-      "Definir cuándo insistir, cuándo reconectar y cuándo cerrar la conversación.",
-      `Diseñar primero el ${playbookTitles[submission.vertical]["follow-up"].toLowerCase()}.`,
-      "Asegurar que cada lead tenga una siguiente acción definida, no solo una primera respuesta.",
+      "Definir cuándo volver a escribir y cuándo dar la conversación por cerrada.",
+      getFirstStepLabel(submission, "follow-up"),
+      "Asegurar que cada conversación tenga un siguiente paso y no se quede en visto.",
     ],
   };
 

--- a/app/actions/diagnostic.ts
+++ b/app/actions/diagnostic.ts
@@ -1,0 +1,241 @@
+'use server';
+
+import {
+  type BookingFlowBand,
+  type DiagnosticActionState,
+  type DiagnosticFocus,
+  type DiagnosticPriority,
+  type DiagnosticRecommendation,
+  type DiagnosticSubmission,
+  type DiagnosticVertical,
+  type LeadVolumeBand,
+  type ResponseTimeBand,
+  isBookingFlowBand,
+  isDiagnosticVertical,
+  isLeadVolumeBand,
+  isResponseTimeBand,
+} from "@/app/actions/diagnostic.shared";
+
+const focusLabels: Record<DiagnosticFocus, string> = {
+  "speed-to-lead": "Velocidad de respuesta",
+  qualification: "Calificación de intención",
+  "agenda-automation": "Agenda y hand-off operativo",
+  "follow-up": "Seguimiento consistente",
+};
+
+const leadVolumeScore: Record<LeadVolumeBand, number> = {
+  "1-20": 0,
+  "21-60": 1,
+  "61-150": 2,
+  "151-plus": 3,
+};
+
+const responseTimeScore: Record<ResponseTimeBand, number> = {
+  "lt-5m": 0,
+  "5-30m": 1,
+  "30-120m": 3,
+  "gt-2h": 4,
+};
+
+const bookingFlowScore: Record<BookingFlowBand, number> = {
+  manual: 2,
+  whatsapp: 1,
+  crm: 0,
+  mixed: 1,
+};
+
+const playbookTitles: Record<DiagnosticVertical, Record<DiagnosticFocus, string>> = {
+  salud: {
+    "speed-to-lead": "Playbook de triage inmediato y agenda clínica",
+    qualification: "Playbook de calificación clínica previa a la cita",
+    "agenda-automation": "Playbook de agenda, confirmación y pre-consulta",
+    "follow-up": "Playbook de recordatorios y reactivación de pacientes",
+  },
+  belleza: {
+    "speed-to-lead": "Playbook de respuesta inmediata y disponibilidad",
+    qualification: "Playbook de calificación de servicio ideal y ticket",
+    "agenda-automation": "Playbook de reserva, confirmación y no-shows",
+    "follow-up": "Playbook de seguimiento post-servicio y recompra",
+  },
+  inmobiliario: {
+    "speed-to-lead": "Playbook de respuesta inmediata y visita priorizada",
+    qualification: "Playbook de presupuesto, zona e intención de compra",
+    "agenda-automation": "Playbook de agenda de visitas y hand-off comercial",
+    "follow-up": "Playbook de seguimiento entre visita, objeciones y cierre",
+  },
+};
+
+export async function generateDiagnosticRecommendation(
+  _previousState: DiagnosticActionState,
+  formData: FormData,
+): Promise<DiagnosticActionState> {
+  const submission = parseDiagnosticSubmission(formData);
+
+  if (!submission) {
+    return {
+      status: "error",
+      message: "Selecciona las cuatro respuestas para generar tu diagnóstico.",
+    };
+  }
+
+  const recommendation = buildRecommendation(submission);
+
+  return {
+    status: "success",
+    message: "Diagnóstico generado.",
+    submitted: submission,
+    recommendation,
+  };
+}
+
+function parseDiagnosticSubmission(formData: FormData): DiagnosticSubmission | null {
+  const vertical = formData.get("vertical");
+  const leadVolume = formData.get("leadVolume");
+  const responseTime = formData.get("responseTime");
+  const bookingFlow = formData.get("bookingFlow");
+  const source = formData.get("source");
+
+  if (
+    typeof vertical !== "string" ||
+    typeof leadVolume !== "string" ||
+    typeof responseTime !== "string" ||
+    typeof bookingFlow !== "string" ||
+    typeof source !== "string"
+  ) {
+    return null;
+  }
+
+  if (
+    !isDiagnosticVertical(vertical) ||
+    !isLeadVolumeBand(leadVolume) ||
+    !isResponseTimeBand(responseTime) ||
+    !isBookingFlowBand(bookingFlow)
+  ) {
+    return null;
+  }
+
+  return {
+    vertical,
+    leadVolume,
+    responseTime,
+    bookingFlow,
+    source,
+  };
+}
+
+function buildRecommendation(submission: DiagnosticSubmission): DiagnosticRecommendation {
+  const focus = resolveFocus(submission);
+  const priority = resolvePriority(submission);
+  const verticalLabel = getVerticalLabel(submission.vertical);
+  const focusLabel = focusLabels[focus];
+
+  return {
+    resultKey: `${submission.vertical}-${submission.leadVolume}-${submission.responseTime}-${submission.bookingFlow}-${Date.now()}`,
+    focus,
+    focusLabel,
+    priority,
+    headline: `Tu palanca principal hoy es ${focusLabel.toLowerCase()}.`,
+    summary: buildSummary(submission, verticalLabel, focus),
+    playbookTitle: playbookTitles[submission.vertical][focus],
+    nextSteps: buildNextSteps(submission, focus),
+  };
+}
+
+function resolveFocus(submission: DiagnosticSubmission): DiagnosticFocus {
+  if (submission.responseTime === "30-120m" || submission.responseTime === "gt-2h") {
+    return "speed-to-lead";
+  }
+
+  if (submission.bookingFlow === "manual" && leadVolumeScore[submission.leadVolume] >= 2) {
+    return "agenda-automation";
+  }
+
+  if (submission.vertical === "inmobiliario" || submission.bookingFlow === "crm" || submission.bookingFlow === "mixed") {
+    return "qualification";
+  }
+
+  return "follow-up";
+}
+
+function resolvePriority(submission: DiagnosticSubmission): DiagnosticPriority {
+  const score =
+    responseTimeScore[submission.responseTime] +
+    leadVolumeScore[submission.leadVolume] +
+    bookingFlowScore[submission.bookingFlow];
+
+  return score >= 4 ? "alta" : "media";
+}
+
+function buildSummary(
+  submission: DiagnosticSubmission,
+  verticalLabel: string,
+  focus: DiagnosticFocus,
+): string {
+  const focusCopy: Record<DiagnosticFocus, string> = {
+    "speed-to-lead":
+      "La intención ya existe, pero se enfría antes de que el equipo la convierta en acción.",
+    qualification:
+      "Responder rápido no basta: hace falta filtrar intención, urgencia y contexto antes de pasar al equipo.",
+    "agenda-automation":
+      "La fuga está en los hand-offs, la disponibilidad y la coordinación operativa para cerrar la siguiente acción.",
+    "follow-up":
+      "El problema no es solo la primera respuesta, sino la constancia para empujar al lead hasta una cita real.",
+  };
+
+  const verticalContext: Record<DiagnosticVertical, string> = {
+    salud:
+      "En salud, cada retraso o pregunta sin contexto empuja al paciente a otra opción o pospone su decisión.",
+    belleza:
+      "En belleza, la rapidez y claridad alrededor de disponibilidad, servicio y confirmación define si la reserva ocurre.",
+    inmobiliario:
+      "En inmobiliario, la conversación necesita identificar intención y preparar la visita correcta sin desperdiciar tiempo comercial.",
+  };
+
+  return `${focusCopy[focus]} ${verticalContext[submission.vertical]} Para ${verticalLabel}, el primer despliegue de Relevo debería enfocarse en ese cuello de botella antes de expandirse a otros módulos.`;
+}
+
+function buildNextSteps(
+  submission: DiagnosticSubmission,
+  focus: DiagnosticFocus,
+): [string, string, string] {
+  const speedSla =
+    submission.responseTime === "gt-2h" || submission.responseTime === "30-120m"
+      ? "Definir un SLA objetivo de respuesta menor a 5 minutos para nuevos leads."
+      : "Blindar el SLA actual para que no dependa de disponibilidad manual del equipo.";
+
+  const focusSteps: Record<DiagnosticFocus, [string, string, string]> = {
+    "speed-to-lead": [
+      speedSla,
+      `Diseñar primero el ${playbookTitles[submission.vertical]["speed-to-lead"].toLowerCase()}.`,
+      "Cerrar el hand-off con agenda o siguiente acción concreta antes de terminar la conversación.",
+    ],
+    qualification: [
+      "Definir 3 a 5 datos obligatorios que separen curiosidad de intención real.",
+      `Diseñar primero el ${playbookTitles[submission.vertical].qualification.toLowerCase()}.`,
+      "Pasar al equipo solo leads con contexto suficiente para avanzar sin retrabajo.",
+    ],
+    "agenda-automation": [
+      "Centralizar disponibilidad, reglas de agenda y confirmaciones en un solo flujo.",
+      `Diseñar primero el ${playbookTitles[submission.vertical]["agenda-automation"].toLowerCase()}.`,
+      "Eliminar pasos manuales entre interés, propuesta de horario y confirmación final.",
+    ],
+    "follow-up": [
+      "Definir cuándo insistir, cuándo reconectar y cuándo cerrar la conversación.",
+      `Diseñar primero el ${playbookTitles[submission.vertical]["follow-up"].toLowerCase()}.`,
+      "Asegurar que cada lead tenga una siguiente acción definida, no solo una primera respuesta.",
+    ],
+  };
+
+  return focusSteps[focus];
+}
+
+function getVerticalLabel(vertical: DiagnosticVertical): string {
+  switch (vertical) {
+    case "salud":
+      return "salud";
+    case "belleza":
+      return "belleza";
+    case "inmobiliario":
+      return "inmobiliario";
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,12 +28,19 @@
 
 html {
   background: var(--background);
+  scroll-behavior: smooth;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-manrope), sans-serif;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 a {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,20 +13,20 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Boreas | Sistema operativo de revenue con IA",
+  title: "Boreas | IA para responder y cerrar mejor",
   description:
-    "Boreas organiza revenue con IA. Relevo, su módulo activo de conversión, responde, califica y empuja leads a acciones concretas para salud, belleza e inmobiliario.",
+    "Boreas ayuda a salud, belleza e inmobiliario a responder más rápido, atender mejor y llevar más conversaciones a citas, visitas y oportunidades.",
   openGraph: {
-    title: "Boreas | Sistema operativo de revenue con IA",
+    title: "Boreas | IA para responder y cerrar mejor",
     description:
-      "Relevo es el módulo de conversión de Boreas: playbooks por industria para responder, calificar y cerrar acciones medibles.",
+      "Relevo es la experiencia de Boreas que hoy ya responde, guía y ayuda a cerrar más conversaciones.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Boreas | Sistema operativo de revenue con IA",
+    title: "Boreas | IA para responder y cerrar mejor",
     description:
-      "Playbooks por industria para convertir conversaciones en acciones medibles en salud, belleza e inmobiliario.",
+      "Más respuestas a tiempo, mejor atención y más citas, visitas y oportunidades.",
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,21 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Boreas | Automatización AI para negocios de belleza",
+  title: "Boreas | Sistema operativo de revenue con IA",
   description:
-    "Automatiza conversaciones, reservas y seguimientos para salones, spas y artistas de belleza con Boreas.",
+    "Boreas organiza revenue con IA. Relevo, su módulo activo de conversión, responde, califica y empuja leads a acciones concretas para salud, belleza e inmobiliario.",
+  openGraph: {
+    title: "Boreas | Sistema operativo de revenue con IA",
+    description:
+      "Relevo es el módulo de conversión de Boreas: playbooks por industria para responder, calificar y cerrar acciones medibles.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Boreas | Sistema operativo de revenue con IA",
+    description:
+      "Playbooks por industria para convertir conversaciones en acciones medibles en salud, belleza e inmobiliario.",
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,15 @@
 import { BoreasHero } from "@/components/hero/boreas-hero";
+import { Header } from "@/components/hero/header";
+import { SiteFooter } from "@/components/layout/site-footer";
 import { BoreasLandingSections } from "@/components/landing/boreas-landing-sections";
 
 export default function Home() {
   return (
-    <>
+    <div className="relative">
+      <Header />
       <BoreasHero />
       <BoreasLandingSections />
-    </>
+      <SiteFooter />
+    </div>
   );
 }

--- a/components/analytics/diagnostic-analytics.tsx
+++ b/components/analytics/diagnostic-analytics.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useRef } from "react";
+
+import type { DiagnosticRecommendation } from "@/app/actions/diagnostic.shared";
+import { trackAnalyticsEvent } from "@/lib/analytics";
+
+const DIAGNOSTIC_SURFACE = "diagnostic_cta_section";
+
+function getFormValue(formData: FormData, key: string): string | undefined {
+  const value = formData.get(key);
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function trackDiagnosticCtaClick() {
+  trackAnalyticsEvent({
+    name: "cta_click",
+    surface: DIAGNOSTIC_SURFACE,
+    meta: {
+      cta_id: "open-diagnostic-flow",
+    },
+  });
+}
+
+export function trackDiagnosticSubmit(formData: FormData) {
+  trackAnalyticsEvent({
+    name: "diagnostic_submit",
+    surface: DIAGNOSTIC_SURFACE,
+    meta: {
+      vertical: getFormValue(formData, "vertical") ?? null,
+      lead_volume: getFormValue(formData, "leadVolume") ?? null,
+      response_time: getFormValue(formData, "responseTime") ?? null,
+      booking_flow: getFormValue(formData, "bookingFlow") ?? null,
+      source: getFormValue(formData, "source") ?? null,
+    },
+  });
+}
+
+export function DiagnosticResultTracker({
+  recommendation,
+  source,
+}: {
+  recommendation?: DiagnosticRecommendation;
+  source: string;
+}) {
+  const lastResultKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!recommendation || lastResultKeyRef.current === recommendation.resultKey) {
+      return;
+    }
+
+    lastResultKeyRef.current = recommendation.resultKey;
+
+    trackAnalyticsEvent({
+      name: "diagnostic_result",
+      surface: DIAGNOSTIC_SURFACE,
+      meta: {
+        source,
+        focus: recommendation.focus,
+        focus_label: recommendation.focusLabel,
+        priority: recommendation.priority,
+        playbook: recommendation.playbookTitle,
+      },
+    });
+  }, [recommendation, source]);
+
+  return null;
+}

--- a/components/analytics/diagnostic-cta-form.tsx
+++ b/components/analytics/diagnostic-cta-form.tsx
@@ -62,18 +62,19 @@ export function DiagnosticCtaForm() {
   return (
     <div className="grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-start">
       <div className="max-w-xl">
-        <p className="text-[0.68rem] uppercase tracking-[0.38em] text-white/30">CTA de diagnóstico</p>
+        <p className="text-[0.68rem] uppercase tracking-[0.38em] text-white/30">Diagnóstico rápido</p>
         <h2 className="mt-6 text-balance text-[clamp(2.35rem,4.8vw,4.75rem)] font-medium leading-[1.04] tracking-[-0.05em] text-[#f7f1ea]">
-          Recibe una recomendación útil antes de hablar con nosotros.
+          Descubre qué te ayudaría más a cerrar mejor.
         </h2>
         <p className="mt-6 max-w-2xl text-base leading-7 text-white/56 sm:text-lg">
-          Responde cuatro preguntas y Boreas te devuelve cuál es el cuello de botella más urgente, qué tipo de playbook debería arrancar primero y qué ajustar para que Relevo convierta mejor.
+          Responde cuatro preguntas y Boreas te dirá qué deberías resolver primero para atender
+          mejor y llevar más conversaciones a una cita, visita o llamada.
         </p>
 
         <div className="mt-8 flex flex-wrap gap-3 text-sm text-white/45">
-          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Sin correo obligatorio</span>
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Sin dejar correo</span>
           <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Menos de 30 segundos</span>
-          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Recomendación inmediata</span>
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Respuesta al momento</span>
         </div>
 
         <button
@@ -81,7 +82,7 @@ export function DiagnosticCtaForm() {
           onClick={handlePrimaryCtaClick}
           className="mt-10 inline-flex items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.22)_0%,rgba(216,204,178,0.12)_100%)] px-8 py-4 text-[1rem] font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_18px_44px_rgba(0,0,0,0.25)] backdrop-blur-xl transition-all duration-300 hover:scale-[1.02] hover:border-[#d8ccb2]/30"
         >
-          Quiero mi diagnóstico express
+          Quiero verlo
         </button>
       </div>
 
@@ -96,7 +97,7 @@ export function DiagnosticCtaForm() {
           <input type="hidden" name="source" value={SOURCE} />
 
           <fieldset className="space-y-3">
-            <legend className="text-sm font-medium tracking-wide text-[#d8ccb2]">1. ¿En qué vertical vendes?</legend>
+            <legend className="text-sm font-medium tracking-wide text-[#d8ccb2]">1. ¿A qué te dedicas?</legend>
             <div className="grid gap-3 sm:grid-cols-3">
               {verticalOptions.map((option) => {
                 const checked = draft.vertical === option.value;
@@ -129,7 +130,7 @@ export function DiagnosticCtaForm() {
 
           <div className="grid gap-4 sm:grid-cols-3">
             <label className="space-y-2 text-sm text-white/64">
-              <span className="font-medium tracking-wide text-[#d8ccb2]">2. ¿Cuántos leads entran?</span>
+              <span className="font-medium tracking-wide text-[#d8ccb2]">2. ¿Cuántos contactos te llegan?</span>
               <select
                 name="leadVolume"
                 value={draft.leadVolume}
@@ -149,7 +150,7 @@ export function DiagnosticCtaForm() {
             </label>
 
             <label className="space-y-2 text-sm text-white/64">
-              <span className="font-medium tracking-wide text-[#d8ccb2]">3. ¿Qué tan rápido responden?</span>
+              <span className="font-medium tracking-wide text-[#d8ccb2]">3. ¿Cuánto tardan en contestar?</span>
               <select
                 name="responseTime"
                 value={draft.responseTime}
@@ -169,7 +170,7 @@ export function DiagnosticCtaForm() {
             </label>
 
             <label className="space-y-2 text-sm text-white/64">
-              <span className="font-medium tracking-wide text-[#d8ccb2]">4. ¿Cómo operan hoy?</span>
+              <span className="font-medium tracking-wide text-[#d8ccb2]">4. ¿Cómo cierran hoy una cita o visita?</span>
               <select
                 name="bookingFlow"
                 value={draft.bookingFlow}
@@ -191,7 +192,8 @@ export function DiagnosticCtaForm() {
 
           <div className="flex flex-col gap-4 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
             <p className="max-w-xl text-sm leading-6 text-white/45">
-              Esta base no guarda datos ni dispara integraciones externas. Solo calcula una recomendación inicial y deja eventos listos para enganchar analytics después.
+              No te pedimos correo ni conectamos nada. Solo te damos una primera recomendación para
+              ver por dónde empezar.
             </p>
             <DiagnosticSubmitButton disabled={!isReadyToSubmit} />
           </div>
@@ -226,12 +228,14 @@ export function DiagnosticCtaForm() {
             <p className="mt-3 text-base leading-7 text-white/62">{state.recommendation.summary}</p>
 
             <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 p-4">
-              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">Playbook recomendado</p>
+              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">
+                Lo primero que conviene activar
+              </p>
               <p className="mt-2 text-base font-medium text-[#f7f1ea]">{state.recommendation.playbookTitle}</p>
             </div>
 
             <div className="mt-5">
-              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">Qué haría Boreas primero</p>
+              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">Qué haríamos primero</p>
               <ul className="mt-3 space-y-3 text-sm leading-6 text-white/58">
                 {state.recommendation.nextSteps.map((step) => (
                   <li key={step} className="flex gap-3">

--- a/components/analytics/diagnostic-cta-form.tsx
+++ b/components/analytics/diagnostic-cta-form.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useActionState, useMemo, useRef, useState } from "react";
+
+import { generateDiagnosticRecommendation } from "@/app/actions/diagnostic";
+import {
+  type BookingFlowBand,
+  type DiagnosticVertical,
+  type LeadVolumeBand,
+  type ResponseTimeBand,
+  bookingFlowOptions,
+  initialDiagnosticActionState,
+  leadVolumeOptions,
+  responseTimeOptions,
+  verticalOptions,
+} from "@/app/actions/diagnostic.shared";
+import { DiagnosticResultTracker, trackDiagnosticCtaClick, trackDiagnosticSubmit } from "@/components/analytics/diagnostic-analytics";
+import { DiagnosticSubmitButton } from "@/components/analytics/diagnostic-submit-button";
+
+const SOURCE = "landing-diagnostic-cta";
+
+type DraftState = {
+  vertical: DiagnosticVertical | "";
+  leadVolume: LeadVolumeBand | "";
+  responseTime: ResponseTimeBand | "";
+  bookingFlow: BookingFlowBand | "";
+};
+
+const initialDraftState: DraftState = {
+  vertical: "",
+  leadVolume: "",
+  responseTime: "",
+  bookingFlow: "",
+};
+
+export function DiagnosticCtaForm() {
+  const [state, formAction] = useActionState(generateDiagnosticRecommendation, initialDiagnosticActionState);
+  const [draft, setDraft] = useState<DraftState>(initialDraftState);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const isReadyToSubmit = useMemo(() => {
+    return Boolean(draft.vertical && draft.leadVolume && draft.responseTime && draft.bookingFlow);
+  }, [draft.bookingFlow, draft.leadVolume, draft.responseTime, draft.vertical]);
+
+  function updateDraft<K extends keyof DraftState>(key: K, value: DraftState[K]) {
+    setDraft((current) => ({
+      ...current,
+      [key]: value,
+    }));
+  }
+
+  function handlePrimaryCtaClick() {
+    trackDiagnosticCtaClick();
+    formRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    formRef.current?.querySelector<HTMLInputElement>("input[name='vertical']")?.focus();
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    trackDiagnosticSubmit(new FormData(event.currentTarget));
+  }
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-start">
+      <div className="max-w-xl">
+        <p className="text-[0.68rem] uppercase tracking-[0.38em] text-white/30">CTA de diagnóstico</p>
+        <h2 className="mt-6 text-balance text-[clamp(2.35rem,4.8vw,4.75rem)] font-medium leading-[1.04] tracking-[-0.05em] text-[#f7f1ea]">
+          Recibe una recomendación útil antes de hablar con nosotros.
+        </h2>
+        <p className="mt-6 max-w-2xl text-base leading-7 text-white/56 sm:text-lg">
+          Responde cuatro preguntas y Boreas te devuelve cuál es el cuello de botella más urgente, qué tipo de playbook debería arrancar primero y qué ajustar para que Relevo convierta mejor.
+        </p>
+
+        <div className="mt-8 flex flex-wrap gap-3 text-sm text-white/45">
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Sin correo obligatorio</span>
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Menos de 30 segundos</span>
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2">Recomendación inmediata</span>
+        </div>
+
+        <button
+          type="button"
+          onClick={handlePrimaryCtaClick}
+          className="mt-10 inline-flex items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.22)_0%,rgba(216,204,178,0.12)_100%)] px-8 py-4 text-[1rem] font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_18px_44px_rgba(0,0,0,0.25)] backdrop-blur-xl transition-all duration-300 hover:scale-[1.02] hover:border-[#d8ccb2]/30"
+        >
+          Quiero mi diagnóstico express
+        </button>
+      </div>
+
+      <div className="rounded-[2rem] border border-white/10 bg-white/[0.035] p-5 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-7">
+        <form
+          ref={formRef}
+          action={formAction}
+          onSubmit={handleSubmit}
+          className="space-y-6"
+          id="boreas-diagnostic-form"
+        >
+          <input type="hidden" name="source" value={SOURCE} />
+
+          <fieldset className="space-y-3">
+            <legend className="text-sm font-medium tracking-wide text-[#d8ccb2]">1. ¿En qué vertical vendes?</legend>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {verticalOptions.map((option) => {
+                const checked = draft.vertical === option.value;
+
+                return (
+                  <label
+                    key={option.value}
+                    className={`flex cursor-pointer flex-col rounded-[1.4rem] border p-4 transition-colors ${
+                      checked
+                        ? "border-[#d8ccb2]/55 bg-[rgba(216,204,178,0.12)] text-[#f7f1ea]"
+                        : "border-white/10 bg-white/[0.02] text-white/62 hover:border-white/18 hover:bg-white/[0.05]"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="vertical"
+                      value={option.value}
+                      checked={checked}
+                      onChange={() => updateDraft("vertical", option.value)}
+                      className="sr-only"
+                      required
+                    />
+                    <span className="text-base font-medium">{option.label}</span>
+                    <span className="mt-2 text-sm leading-6">{option.hint}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <label className="space-y-2 text-sm text-white/64">
+              <span className="font-medium tracking-wide text-[#d8ccb2]">2. ¿Cuántos leads entran?</span>
+              <select
+                name="leadVolume"
+                value={draft.leadVolume}
+                onChange={(event) => updateDraft("leadVolume", event.target.value as LeadVolumeBand)}
+                className="min-h-12 w-full rounded-2xl border border-white/10 bg-[#0f0f10] px-4 text-sm text-[#f7f1ea] outline-none transition-colors focus:border-[#d8ccb2]/45"
+                required
+              >
+                <option value="" disabled>
+                  Selecciona una opción
+                </option>
+                {leadVolumeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-2 text-sm text-white/64">
+              <span className="font-medium tracking-wide text-[#d8ccb2]">3. ¿Qué tan rápido responden?</span>
+              <select
+                name="responseTime"
+                value={draft.responseTime}
+                onChange={(event) => updateDraft("responseTime", event.target.value as ResponseTimeBand)}
+                className="min-h-12 w-full rounded-2xl border border-white/10 bg-[#0f0f10] px-4 text-sm text-[#f7f1ea] outline-none transition-colors focus:border-[#d8ccb2]/45"
+                required
+              >
+                <option value="" disabled>
+                  Selecciona una opción
+                </option>
+                {responseTimeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-2 text-sm text-white/64">
+              <span className="font-medium tracking-wide text-[#d8ccb2]">4. ¿Cómo operan hoy?</span>
+              <select
+                name="bookingFlow"
+                value={draft.bookingFlow}
+                onChange={(event) => updateDraft("bookingFlow", event.target.value as BookingFlowBand)}
+                className="min-h-12 w-full rounded-2xl border border-white/10 bg-[#0f0f10] px-4 text-sm text-[#f7f1ea] outline-none transition-colors focus:border-[#d8ccb2]/45"
+                required
+              >
+                <option value="" disabled>
+                  Selecciona una opción
+                </option>
+                {bookingFlowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="flex flex-col gap-4 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
+            <p className="max-w-xl text-sm leading-6 text-white/45">
+              Esta base no guarda datos ni dispara integraciones externas. Solo calcula una recomendación inicial y deja eventos listos para enganchar analytics después.
+            </p>
+            <DiagnosticSubmitButton disabled={!isReadyToSubmit} />
+          </div>
+
+          {state.message && state.status === "error" ? (
+            <p className="rounded-2xl border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+              {state.message}
+            </p>
+          ) : null}
+        </form>
+
+        <DiagnosticResultTracker recommendation={state.recommendation} source={SOURCE} />
+
+        {state.recommendation ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mt-6 rounded-[1.75rem] border border-[#d8ccb2]/20 bg-[linear-gradient(180deg,rgba(216,204,178,0.12)_0%,rgba(255,255,255,0.02)_100%)] p-5 text-left shadow-[0_20px_80px_rgba(0,0,0,0.18)]"
+          >
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="rounded-full border border-white/12 bg-white/[0.06] px-3 py-1 text-[0.68rem] uppercase tracking-[0.32em] text-white/42">
+                Prioridad {state.recommendation.priority}
+              </span>
+              <span className="rounded-full border border-[#d8ccb2]/20 bg-[rgba(216,204,178,0.08)] px-3 py-1 text-[0.68rem] uppercase tracking-[0.32em] text-[#d8ccb2]">
+                {state.recommendation.focusLabel}
+              </span>
+            </div>
+
+            <h3 className="mt-5 text-2xl font-medium tracking-[-0.03em] text-[#f7f1ea]">
+              {state.recommendation.headline}
+            </h3>
+            <p className="mt-3 text-base leading-7 text-white/62">{state.recommendation.summary}</p>
+
+            <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 p-4">
+              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">Playbook recomendado</p>
+              <p className="mt-2 text-base font-medium text-[#f7f1ea]">{state.recommendation.playbookTitle}</p>
+            </div>
+
+            <div className="mt-5">
+              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">Qué haría Boreas primero</p>
+              <ul className="mt-3 space-y-3 text-sm leading-6 text-white/58">
+                {state.recommendation.nextSteps.map((step) => (
+                  <li key={step} className="flex gap-3">
+                    <span className="mt-2 h-1.5 w-1.5 rounded-full bg-[#d8ccb2]" />
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/analytics/diagnostic-submit-button.tsx
+++ b/components/analytics/diagnostic-submit-button.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useFormStatus } from "react-dom";
+
+export function DiagnosticSubmitButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={disabled || pending}
+      className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.22)_0%,rgba(216,204,178,0.12)_100%)] px-6 py-3 text-sm font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_18px_44px_rgba(0,0,0,0.25)] backdrop-blur-xl transition-all duration-300 hover:scale-[1.01] hover:border-[#d8ccb2]/30 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:scale-100"
+    >
+      {pending ? "Generando diagnóstico..." : "Ver mi recomendación"}
+    </button>
+  );
+}

--- a/components/hero/boreas-hero.tsx
+++ b/components/hero/boreas-hero.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { useRef } from "react";
 
 import { heroWords } from "@/content/boreas-home";
-import { Header } from "@/components/hero/header";
 import { MacbookShowcase } from "@/components/hero/macbook-showcase";
 import { RotatingHeadline } from "@/components/hero/rotating-headline";
 
@@ -131,7 +130,7 @@ export function BoreasHero() {
   return (
     <section
       ref={sectionRef}
-      className="relative min-h-[180svh] overflow-clip bg-[#0e1114] text-[#f5f1ea]"
+      className="relative min-h-[155svh] overflow-clip bg-[#0e1114] text-[#f5f1ea] lg:min-h-[165svh]"
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.05),transparent_42%),linear-gradient(180deg,#0e1114_0%,#0f1318_46%,#0d1013_100%)]" />
       <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.03)_0%,transparent_16%,transparent_84%,rgba(255,255,255,0.03)_100%)]" />
@@ -139,81 +138,84 @@ export function BoreasHero() {
       <TopographicBackdrop />
 
       <div className="sticky top-0 flex min-h-[100svh] flex-col">
-        <Header />
-
         <div className="relative flex flex-1 items-center">
-          <div className="mx-auto flex w-full max-w-[1440px] flex-col items-center px-4 pb-12 pt-10 sm:px-6 lg:px-10 lg:pb-14">
-            <motion.div
-              initial={{ opacity: 0, y: reduceMotion ? 0 : 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, ease: [0.22, 1, 0.36, 1] }}
-              style={{ y: copyY, opacity: copyOpacity }}
-              className="relative z-10 flex max-w-[860px] flex-col items-center text-center"
-            >
-              <p className="text-[0.72rem] uppercase tracking-[0.42em] text-white/34">
-                Boreas · Sistema operativo de revenue
-              </p>
+          <div className="mx-auto w-full max-w-[1460px] px-4 pb-12 pt-24 sm:px-6 lg:px-10 lg:pb-14 lg:pt-28">
+            <div className="relative z-10 grid items-center gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:gap-16">
+              <motion.div
+                initial={{ opacity: 0, y: reduceMotion ? 0 : 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.75, ease: [0.22, 1, 0.36, 1] }}
+                style={{ y: copyY, opacity: copyOpacity }}
+                className="flex flex-col items-center text-center lg:items-start lg:text-left"
+              >
+                <p className="text-[0.72rem] uppercase tracking-[0.42em] text-white/34">
+                  Responde más rápido. Cierra mejor.
+                </p>
 
-              <h1 className="mt-6 flex max-w-[14ch] flex-col items-center text-center text-[clamp(3.5rem,10vw,7.6rem)] font-medium leading-[0.98] tracking-[-0.075em] text-[#f7f1ea]">
-                <span className="block text-[#c5ccd2]">Revenue estructurado para</span>
-                <span className="mt-1 block min-h-[1.22em]">
-                  <RotatingHeadline words={heroWords} />
-                </span>
-              </h1>
+                <h1 className="mt-6 flex max-w-[13ch] flex-col items-center text-center text-[clamp(3.4rem,9vw,7rem)] font-medium leading-[0.98] tracking-[-0.075em] text-[#f7f1ea] lg:items-start lg:text-left">
+                  <span className="block text-[#c5ccd2]">Más conversaciones bien atendidas para</span>
+                  <span className="mt-1 block min-h-[1.22em]">
+                    <RotatingHeadline words={heroWords} />
+                  </span>
+                </h1>
 
-              <p className="mt-8 max-w-[46rem] text-base leading-8 text-white/58 sm:text-lg">
-                Boreas organiza adquisición, conversión y retención como un
-                sistema. Relevo es el módulo activo que hoy responde, califica y
-                empuja leads a acciones concretas con playbooks por industria.
-              </p>
+                <p className="mt-8 max-w-[34rem] text-base leading-8 text-white/58 sm:text-lg">
+                  Hoy Relevo ya contesta al momento, orienta cada conversación y la lleva a una
+                  cita, visita o siguiente paso claro sin dejar a la persona esperando.
+                </p>
 
-              <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
-                <a
-                  href="#diagnostico"
-                  className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.11)_100%)] px-6 py-3.5 text-sm font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_14px_34px_rgba(0,0,0,0.18)] backdrop-blur-xl transition-all duration-500 hover:scale-[1.015] hover:border-white/22 hover:bg-[linear-gradient(180deg,rgba(216,204,178,0.24)_0%,rgba(216,204,178,0.16)_100%)] hover:brightness-105"
-                >
-                  Recibir diagnóstico inicial
-                </a>
+                <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row lg:items-start">
+                  <a
+                    href="#diagnostico"
+                    className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.11)_100%)] px-6 py-3.5 text-sm font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_14px_34px_rgba(0,0,0,0.18)] backdrop-blur-xl transition-all duration-500 hover:scale-[1.015] hover:border-white/22 hover:bg-[linear-gradient(180deg,rgba(216,204,178,0.24)_0%,rgba(216,204,178,0.16)_100%)] hover:brightness-105"
+                  >
+                    Ver diagnóstico
+                  </a>
 
-                <Link
-                  href="#demo"
-                  className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/12 bg-white/[0.03] px-6 py-3.5 text-sm font-medium text-[#f5f1ea] transition-all duration-300 hover:border-white/20 hover:bg-white/[0.06]"
-                >
-                  Ver Relevo en acción
-                </Link>
-              </div>
+                  <a
+                    href="https://relevo.chat"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/12 bg-white/[0.03] px-6 py-3.5 text-sm font-medium text-[#f5f1ea] transition-all duration-300 hover:border-white/20 hover:bg-white/[0.06]"
+                  >
+                    Abrir Relevo
+                  </a>
+                </div>
 
-              <div className="mt-8 flex flex-wrap items-center justify-center gap-2 text-[0.68rem] uppercase tracking-[0.26em] text-white/34">
-                <span className="rounded-full border border-white/10 px-3 py-2">
-                  Playbooks por industria
-                </span>
-                <span className="rounded-full border border-white/10 px-3 py-2">
-                  Conversión activa ahora
-                </span>
-                <span className="rounded-full border border-white/10 px-3 py-2">
-                  Medición desde el día uno
-                </span>
-              </div>
-            </motion.div>
+                <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-white/46">
+                  <Link href="#demo-relevo" className="transition-colors duration-300 hover:text-white">
+                    Ver demo en la página
+                  </Link>
+                  <span className="h-1 w-1 rounded-full bg-white/18" />
+                  <span>Responde al instante</span>
+                  <span className="h-1 w-1 rounded-full bg-white/18" />
+                  <span>Guía cada contacto</span>
+                  <span className="h-1 w-1 rounded-full bg-white/18" />
+                  <span>Ayuda a cerrar citas y visitas</span>
+                </div>
+              </motion.div>
 
-            <motion.div
-              initial={{ opacity: 0, y: reduceMotion ? 0 : 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{
-                duration: 0.85,
-                delay: 0.12,
-                ease: [0.22, 1, 0.36, 1],
-              }}
-              style={{
-                y: artifactY,
-                opacity: artifactOpacity,
-                scale: artifactScale,
-                filter: artifactFilter,
-              }}
-              className="relative z-10 mt-14 w-full lg:mt-16"
-            >
-              <MacbookShowcase />
-            </motion.div>
+              <motion.div
+                initial={{ opacity: 0, y: reduceMotion ? 0 : 40 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{
+                  duration: 0.85,
+                  delay: 0.12,
+                  ease: [0.22, 1, 0.36, 1],
+                }}
+                style={{
+                  y: artifactY,
+                  opacity: artifactOpacity,
+                  scale: artifactScale,
+                  filter: artifactFilter,
+                }}
+                className="mt-12 w-full lg:mt-0"
+              >
+                <div className="lg:pl-4">
+                  <MacbookShowcase id="demo-hero" />
+                </div>
+              </motion.div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/hero/boreas-hero.tsx
+++ b/components/hero/boreas-hero.tsx
@@ -4,18 +4,10 @@ import { motion, useMotionTemplate, useReducedMotion, useScroll, useTransform } 
 import Link from "next/link";
 import { useRef } from "react";
 
+import { heroWords } from "@/content/boreas-home";
 import { Header } from "@/components/hero/header";
 import { MacbookShowcase } from "@/components/hero/macbook-showcase";
 import { RotatingHeadline } from "@/components/hero/rotating-headline";
-
-const rotatingWords = [
-  "citas",
-  "pacientes",
-  "clientes",
-  "reservas",
-  "leads",
-  "ingresos",
-];
 
 const contourPaths = [
   "M-80 220C90 130 250 140 420 220C610 312 760 304 980 220C1150 154 1300 154 1505 256C1630 320 1740 320 1840 268",
@@ -159,35 +151,48 @@ export function BoreasHero() {
               className="relative z-10 flex max-w-[860px] flex-col items-center text-center"
             >
               <p className="text-[0.72rem] uppercase tracking-[0.42em] text-white/34">
-                Boreas · La IA a tu favor
+                Boreas · Sistema operativo de revenue
               </p>
 
-              <h1 className="mt-6 flex max-w-[12ch] flex-col items-center text-center text-[clamp(4.1rem,11vw,8.3rem)] font-medium leading-[0.98] tracking-[-0.075em] text-[#f7f1ea]">
-                <span className="block text-[#c5ccd2]">Más</span>
+              <h1 className="mt-6 flex max-w-[14ch] flex-col items-center text-center text-[clamp(3.5rem,10vw,7.6rem)] font-medium leading-[0.98] tracking-[-0.075em] text-[#f7f1ea]">
+                <span className="block text-[#c5ccd2]">Revenue estructurado para</span>
                 <span className="mt-1 block min-h-[1.22em]">
-                  <RotatingHeadline words={rotatingWords} />
+                  <RotatingHeadline words={heroWords} />
                 </span>
               </h1>
 
-              <p className="mt-8 max-w-[42rem] text-base leading-8 text-white/58 sm:text-lg">
-                Automatización inteligente para negocios que quieren llenar su
-                agenda sin perseguir mensajes.
+              <p className="mt-8 max-w-[46rem] text-base leading-8 text-white/58 sm:text-lg">
+                Boreas organiza adquisición, conversión y retención como un
+                sistema. Relevo es el módulo activo que hoy responde, califica y
+                empuja leads a acciones concretas con playbooks por industria.
               </p>
 
               <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
                 <a
-                  href="mailto:hola@boreas.ai"
+                  href="#diagnostico"
                   className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.11)_100%)] px-6 py-3.5 text-sm font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_14px_34px_rgba(0,0,0,0.18)] backdrop-blur-xl transition-all duration-500 hover:scale-[1.015] hover:border-white/22 hover:bg-[linear-gradient(180deg,rgba(216,204,178,0.24)_0%,rgba(216,204,178,0.16)_100%)] hover:brightness-105"
                 >
-                  Agendar llamada
+                  Recibir diagnóstico inicial
                 </a>
 
                 <Link
                   href="#demo"
                   className="inline-flex min-w-[13rem] items-center justify-center rounded-full border border-white/12 bg-white/[0.03] px-6 py-3.5 text-sm font-medium text-[#f5f1ea] transition-all duration-300 hover:border-white/20 hover:bg-white/[0.06]"
                 >
-                  Ver cómo funciona
+                  Ver Relevo en acción
                 </Link>
+              </div>
+
+              <div className="mt-8 flex flex-wrap items-center justify-center gap-2 text-[0.68rem] uppercase tracking-[0.26em] text-white/34">
+                <span className="rounded-full border border-white/10 px-3 py-2">
+                  Playbooks por industria
+                </span>
+                <span className="rounded-full border border-white/10 px-3 py-2">
+                  Conversión activa ahora
+                </span>
+                <span className="rounded-full border border-white/10 px-3 py-2">
+                  Medición desde el día uno
+                </span>
               </div>
             </motion.div>
 

--- a/components/hero/chat-ui.tsx
+++ b/components/hero/chat-ui.tsx
@@ -14,7 +14,7 @@ type LogEntryStatus = "idle" | "running" | "done";
 const INCOMING_MESSAGE =
   "Quiero avanzar esta semana. ¿Qué opción me recomiendan?";
 const RELEVO_REPLY =
-  "Sí. Ya califiqué tu caso y el playbook sugiere una llamada inicial este domingo 21 de junio a las 4:30 PM. ¿Te la aparto ahora?";
+  "Sí. Ya vi lo que necesitas y te recomiendo una llamada inicial este domingo 21 de junio a las 4:30 PM. ¿Te la aparto ahora?";
 
 /* ─── Activity Log data (telemetry-style) ─── */
 interface LogEntry {
@@ -24,11 +24,11 @@ interface LogEntry {
 }
 
 const ENGINE_LOG: LogEntry[] = [
-  { tag: "QUALIFY", label: "Calificación de lead", output: "listo para avanzar · 0.94" },
-  { tag: "PLAYBOOK", label: "Playbook activo", output: "conversión · primer contacto" },
-  { tag: "SIGNALS", label: "Señales clave", output: "intención: cita · objeción: horario" },
-  { tag: "ADVANCE", label: "Próximo paso", output: "llamada inicial · 30 min" },
-  { tag: "PUSH", label: "Empuje a acción", output: "confirmar ahora" },
+  { tag: "NECES", label: "Qué busca", output: "quiere avanzar esta semana" },
+  { tag: "RUTA", label: "Ruta elegida", output: "llamada inicial" },
+  { tag: "DUDAS", label: "Punto a resolver", output: "horario" },
+  { tag: "PASO", label: "Siguiente paso", output: "domingo 4:30 PM" },
+  { tag: "CIERRE", label: "Acción", output: "apartar ahora" },
 ];
 
 function createInitialLogStates(): LogEntryStatus[] {
@@ -206,7 +206,7 @@ function StaticChatUI() {
           <MessageBubble align="right" sender="Cliente" text="Hola, quiero avanzar esta semana." />
           <MessageBubble
             sender="Relevo"
-            text="Perfecto. Relevo ya activó el playbook de conversión y te propongo los siguientes pasos disponibles."
+            text="Perfecto. Relevo ya entendió lo que buscas y te propone las mejores opciones para avanzar."
           />
 
           <div className="flex flex-wrap gap-2 pl-1">
@@ -218,7 +218,7 @@ function StaticChatUI() {
           <MessageBubble sender="Relevo">
             <p className="text-[0.68rem] uppercase tracking-[0.28em] text-white/35">Relevo</p>
             <p className="mt-2 text-sm leading-6">
-              El mejor siguiente paso es hoy a las 5:30 PM. Si me dices que sí, Relevo lo confirma y sigue el flujo automático.
+              El mejor siguiente paso es hoy a las 5:30 PM. Si me dices que sí, Relevo lo confirma y te acompaña hasta cerrar.
             </p>
             <AppointmentCard />
           </MessageBubble>
@@ -532,7 +532,7 @@ function InteractiveChatUI() {
       >
         {/* Chat panel */}
         <div ref={chatPanelRef} className="flex min-h-0 flex-col justify-end">
-          <p className="mb-2 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que ve el lead</p>
+          <p className="mb-2 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que ve la persona</p>
           <div
             className="relative flex max-w-[31rem] flex-col gap-1.5"
             style={{ maskImage: "linear-gradient(to bottom, transparent 0%, black 12%)", WebkitMaskImage: "linear-gradient(to bottom, transparent 0%, black 12%)" }}
@@ -540,7 +540,7 @@ function InteractiveChatUI() {
 
             {/* Conversation history (pre-existing) */}
             <MessageBubble align="right" sender="Cliente" text="Vi su anuncio, pero no sé cuál sería el mejor siguiente paso." muted />
-            <MessageBubble sender="Relevo" text="No pasa nada. Relevo lo califica y te lleva a la acción más probable." muted />
+            <MessageBubble sender="Relevo" text="No pasa nada. Relevo entiende qué busca y lo lleva al siguiente paso más probable." muted />
 
             {/* Current demo flow */}
             <MessageBubble
@@ -581,11 +581,11 @@ function InteractiveChatUI() {
 
         {/* Engine Activity Log */}
         <div ref={enginePanelRef} className="flex min-w-0 flex-col gap-3 transition-opacity duration-500 lg:min-w-[20rem]">
-          <p className="mb-0 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que procesa Relevo</p>
+          <p className="mb-0 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que revisa Relevo</p>
           <div className="flex flex-1 flex-col rounded-[1.65rem] border border-white/8 bg-white/[0.03] p-4 shadow-[0_18px_60px_rgba(0,0,0,0.16)]">
             <div className="flex items-center justify-between">
               <p className="font-mono text-[0.62rem] uppercase tracking-[0.34em] text-white/28">
-                Conversion Log
+                Resumen
               </p>
               <span className={`flex items-center gap-1.5 rounded-full px-2 py-0.5 font-mono text-[0.56rem] uppercase tracking-wider ${
                 phase === "done"
@@ -600,7 +600,7 @@ function InteractiveChatUI() {
                     <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   </svg>
                 )}
-                {phase === "done" ? "listo" : phase === "engine" || phase === "typing" ? "procesando" : "espera"}
+                {phase === "done" ? "listo" : phase === "engine" || phase === "typing" ? "revisando" : "espera"}
               </span>
             </div>
 
@@ -634,10 +634,10 @@ function InteractiveChatUI() {
               />
             </div>
             <p className="mt-1.5 font-mono text-[11px] leading-5 text-white/40">
-              {phase === "idle" && "Esperando lead entrante para activar Relevo…"}
-              {phase === "engine" && "Relevo califica el lead, activa playbook y define el siguiente paso."}
-              {phase === "typing" && "Relevo compone la respuesta y empuja a una acción concreta."}
-              {phase === "done" && "Lead calificado · playbook ejecutado · siguiente paso empujado"}
+              {phase === "idle" && "Esperando una nueva conversación para que Relevo entre en acción…"}
+              {phase === "engine" && "Relevo entiende qué busca la persona y decide cómo ayudarla a avanzar."}
+              {phase === "typing" && "Relevo prepara la respuesta y propone el mejor siguiente paso."}
+              {phase === "done" && "Conversación entendida · mejor siguiente paso listo"}
             </p>
           </div>
         </div>
@@ -648,7 +648,7 @@ function InteractiveChatUI() {
         <div className="flex items-center justify-between gap-3 rounded-[1.3rem] border border-white/8 bg-black/20 px-4 py-3">
           <div className="min-w-0">
             <p className="text-[0.62rem] uppercase tracking-[0.24em] text-white/28">
-              Lead entrante
+              Mensaje entrante
             </p>
             <div className="mt-1 flex min-h-6 items-center gap-1 overflow-hidden">
               <span
@@ -691,11 +691,11 @@ export function ChatUI({ mode = "static" }: { mode?: ChatUIMode }) {
       <div className="flex items-center justify-between border-b border-white/6 px-5 py-4 sm:px-6">
         <div>
           <p className="text-[0.62rem] uppercase tracking-[0.34em] text-white/28">
-            Boreas OS
+            Boreas
           </p>
           <div className="mt-2 flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-[#d4c0a1] shadow-[0_0_14px_rgba(212,192,161,0.5)]" />
-            <span className="text-sm text-[#f5f1ea]">Relevo · motor de conversión</span>
+            <span className="text-sm text-[#f5f1ea]">Relevo · atención que guía y convierte</span>
           </div>
         </div>
 

--- a/components/hero/chat-ui.tsx
+++ b/components/hero/chat-ui.tsx
@@ -11,9 +11,10 @@ gsap.registerPlugin(useGSAP, ScrollTrigger);
 type ChatUIMode = "static" | "simulator";
 type LogEntryStatus = "idle" | "running" | "done";
 
-const INCOMING_MESSAGE = "Me encantaría. ¿Qué día tienen disponible?";
-const BOREAS_REPLY =
-  "¡Claro! Tengo un espacio este domingo 21 de junio a las 4:30 PM. ¿Te lo confirmo?";
+const INCOMING_MESSAGE =
+  "Quiero avanzar esta semana. ¿Qué opción me recomiendan?";
+const RELEVO_REPLY =
+  "Sí. Ya califiqué tu caso y el playbook sugiere una llamada inicial este domingo 21 de junio a las 4:30 PM. ¿Te la aparto ahora?";
 
 /* ─── Activity Log data (telemetry-style) ─── */
 interface LogEntry {
@@ -23,11 +24,11 @@ interface LogEntry {
 }
 
 const ENGINE_LOG: LogEntry[] = [
-  { tag: "INTENT",   label: "Clasif. intención",  output: "scheduling · 0.97" },
-  { tag: "EXTRACT",  label: "Extracción",         output: "periodo: semana" },
-  { tag: "QUERY",    label: "Disponibilidad",      output: "3 slots" },
-  { tag: "MATCH",    label: "Match horario",       output: "dom 21/06 16:30" },
-  { tag: "COMPOSE",  label: "Respuesta",           output: "42 tok · brand_v2" },
+  { tag: "QUALIFY", label: "Calificación de lead", output: "listo para avanzar · 0.94" },
+  { tag: "PLAYBOOK", label: "Playbook activo", output: "conversión · primer contacto" },
+  { tag: "SIGNALS", label: "Señales clave", output: "intención: cita · objeción: horario" },
+  { tag: "ADVANCE", label: "Próximo paso", output: "llamada inicial · 30 min" },
+  { tag: "PUSH", label: "Empuje a acción", output: "confirmar ahora" },
 ];
 
 function createInitialLogStates(): LogEntryStatus[] {
@@ -158,15 +159,15 @@ function ActivityLogEntry({
   );
 }
 
-/* ─── Confirmed Appointment Card (embedded in Boreas reply) ─── */
+/* ─── Next Step Card (embedded in Relevo reply) ─── */
 
 function AppointmentCard({ containerRef }: { containerRef?: Ref<HTMLDivElement> }) {
   return (
     <div ref={containerRef} className="mt-2.5 rounded-xl border border-[#d4c0a1]/15 bg-[#171b20] px-3.5 py-3">
       <div className="flex items-center justify-between">
-        <p className="text-xs font-medium text-[#f5f1ea]">Consulta inicial</p>
+        <p className="text-xs font-medium text-[#f5f1ea]">Llamada inicial</p>
         <span className="rounded-full bg-[#d4c0a1]/12 px-2 py-0.5 text-[0.58rem] font-semibold uppercase tracking-[0.2em] text-[#d4c0a1]">
-          confirmada
+          siguiente paso
         </span>
       </div>
       <div className="mt-2 flex items-center gap-3 text-[11px] text-white/40">
@@ -202,22 +203,22 @@ function StaticChatUI() {
     <>
       <div className="grid flex-1 gap-5 px-5 py-5 sm:px-6 lg:grid-cols-[1.25fr_0.75fr]">
         <div className="flex flex-col gap-4">
-          <MessageBubble align="right" sender="Cliente" text="Hola, ¿tienen citas disponibles?" />
+          <MessageBubble align="right" sender="Cliente" text="Hola, quiero avanzar esta semana." />
           <MessageBubble
-            sender="Boreas"
-            text="Sí, te muestro los horarios disponibles para hoy y mañana."
+            sender="Relevo"
+            text="Perfecto. Relevo ya activó el playbook de conversión y te propongo los siguientes pasos disponibles."
           />
 
           <div className="flex flex-wrap gap-2 pl-1">
             <QuickReply label="Hoy 5:30 PM" />
             <QuickReply label="Mañana 11:00 AM" />
-            <QuickReply label="Ver más horarios" />
+            <QuickReply label="Llamada rápida" />
           </div>
 
-          <MessageBubble sender="Boreas">
-            <p className="text-[0.68rem] uppercase tracking-[0.28em] text-white/35">Boreas</p>
+          <MessageBubble sender="Relevo">
+            <p className="text-[0.68rem] uppercase tracking-[0.28em] text-white/35">Relevo</p>
             <p className="mt-2 text-sm leading-6">
-              Perfecto, te agendo para hoy a las 5:30 PM. Te envío confirmación y recordatorio automático.
+              El mejor siguiente paso es hoy a las 5:30 PM. Si me dices que sí, Relevo lo confirma y sigue el flujo automático.
             </p>
             <AppointmentCard />
           </MessageBubble>
@@ -226,17 +227,17 @@ function StaticChatUI() {
         {/* Reservation card (simplified) */}
         <div className="rounded-[1.65rem] border border-white/8 bg-white/[0.03] p-4 shadow-[0_18px_60px_rgba(0,0,0,0.16)]">
           <p className="text-[0.62rem] uppercase tracking-[0.34em] text-white/28">
-            Reserva sugerida
+            Siguiente paso sugerido
           </p>
 
           <div className="mt-4 rounded-[1.35rem] border border-[#d4c0a1]/12 bg-[#171b20] px-4 py-4">
             <div className="flex items-start justify-between gap-3">
               <div>
                 <p className="text-sm font-medium text-[#f5f1ea]">
-                  Consulta inicial
+                  Llamada inicial
                 </p>
                 <p className="mt-1.5 text-xs uppercase tracking-[0.22em] text-white/28">
-                  30 min · Confirmación automática
+                  30 min · Empuje a acción
                 </p>
               </div>
               <span className="rounded-full border border-[#d4c0a1]/18 px-3 py-1 text-[0.62rem] uppercase tracking-[0.24em] text-[#d4c0a1]">
@@ -253,7 +254,7 @@ function StaticChatUI() {
                 >
                   <span>{slot}</span>
                   <span className="text-xs uppercase tracking-[0.2em] text-white/30">
-                    reservar
+                    avanzar
                   </span>
                 </button>
               ))}
@@ -264,9 +265,9 @@ function StaticChatUI() {
 
       <div className="border-t border-white/6 px-5 py-4 sm:px-6">
         <div className="flex items-center justify-between gap-3 rounded-[1.3rem] border border-white/8 bg-black/20 px-4 py-3">
-          <p className="text-sm text-white/38">Responder como Boreas</p>
+          <p className="text-sm text-white/38">Responder como Relevo</p>
           <span className="rounded-full bg-[#d4c0a1] px-3.5 py-2 text-[0.62rem] font-medium uppercase tracking-[0.24em] text-[#0f1215]">
-            Enviar horarios
+            Mover a acción
           </span>
         </div>
       </div>
@@ -431,7 +432,7 @@ function InteractiveChatUI() {
           cumulativeOffset += 380 + Math.floor(Math.random() * 200);
         });
 
-        /* ── Phase 3: Chat back in focus, Boreas types ── */
+        /* ── Phase 3: Chat back in focus, Relevo types ── */
         tl.to(enginePanelRef.current, {
           opacity: 0.6,
           duration: 0.5,
@@ -459,7 +460,7 @@ function InteractiveChatUI() {
           ease: "power2.in",
         });
 
-        /* ── Boreas reply with appointment card ── */
+        /* ── Relevo reply with next-step card ── */
         tl.to(replyBubbleRef.current, {
           autoAlpha: 1,
           y: 0,
@@ -517,8 +518,8 @@ function InteractiveChatUI() {
     phase === "done"
       ? "Repetir demo"
       : phase === "engine" || phase === "typing"
-        ? "Procesando"
-        : "Enviar";
+        ? "Ejecutando"
+        : "Activar Relevo";
   const inputPreview = phase === "idle" ? INCOMING_MESSAGE : "";
 
   return (
@@ -531,15 +532,15 @@ function InteractiveChatUI() {
       >
         {/* Chat panel */}
         <div ref={chatPanelRef} className="flex min-h-0 flex-col justify-end">
-          <p className="mb-2 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que ves</p>
+          <p className="mb-2 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que ve el lead</p>
           <div
             className="relative flex max-w-[31rem] flex-col gap-1.5"
             style={{ maskImage: "linear-gradient(to bottom, transparent 0%, black 12%)", WebkitMaskImage: "linear-gradient(to bottom, transparent 0%, black 12%)" }}
           >
 
             {/* Conversation history (pre-existing) */}
-            <MessageBubble align="right" sender="Cliente" text="Me recomendaron con ustedes." muted />
-            <MessageBubble sender="Boreas" text="Excelentes noticias. ¿Te gustaría agendar una cita?" muted />
+            <MessageBubble align="right" sender="Cliente" text="Vi su anuncio, pero no sé cuál sería el mejor siguiente paso." muted />
+            <MessageBubble sender="Relevo" text="No pasa nada. Relevo lo califica y te lleva a la acción más probable." muted />
 
             {/* Current demo flow */}
             <MessageBubble
@@ -552,7 +553,7 @@ function InteractiveChatUI() {
             <div ref={typingBubbleRef} className="flex justify-start">
               <div className="rounded-[1.5rem] rounded-bl-md border border-white/8 bg-white/[0.04] px-4 py-3 text-[#f5f1ea]">
                 <p className="text-[0.68rem] uppercase tracking-[0.28em] text-white/35">
-                  Boreas
+                  Relevo
                 </p>
                 <div className="mt-2 flex items-center gap-1.5">
                   {[0, 1, 2].map((dot) => (
@@ -569,10 +570,10 @@ function InteractiveChatUI() {
             </div>
 
             <MessageBubble
-              sender="Boreas"
+              sender="Relevo"
               containerRef={replyBubbleRef}
             >
-              <p className="mt-2 text-sm leading-6">{BOREAS_REPLY}</p>
+              <p className="mt-2 text-sm leading-6">{RELEVO_REPLY}</p>
               <AppointmentCard containerRef={appointmentCardRef} />
             </MessageBubble>
           </div>
@@ -580,11 +581,11 @@ function InteractiveChatUI() {
 
         {/* Engine Activity Log */}
         <div ref={enginePanelRef} className="flex min-w-0 flex-col gap-3 transition-opacity duration-500 lg:min-w-[20rem]">
-          <p className="mb-0 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">La magia detrás</p>
+          <p className="mb-0 text-[0.7rem] font-medium uppercase tracking-[0.3em] text-[#d4c0a1]/60">Lo que procesa Relevo</p>
           <div className="flex flex-1 flex-col rounded-[1.65rem] border border-white/8 bg-white/[0.03] p-4 shadow-[0_18px_60px_rgba(0,0,0,0.16)]">
             <div className="flex items-center justify-between">
               <p className="font-mono text-[0.62rem] uppercase tracking-[0.34em] text-white/28">
-                Activity Log
+                Conversion Log
               </p>
               <span className={`flex items-center gap-1.5 rounded-full px-2 py-0.5 font-mono text-[0.56rem] uppercase tracking-wider ${
                 phase === "done"
@@ -599,7 +600,7 @@ function InteractiveChatUI() {
                     <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   </svg>
                 )}
-                {phase === "done" ? "complete" : phase === "engine" || phase === "typing" ? "processing" : "standby"}
+                {phase === "done" ? "listo" : phase === "engine" || phase === "typing" ? "procesando" : "espera"}
               </span>
             </div>
 
@@ -621,7 +622,7 @@ function InteractiveChatUI() {
           {/* Engine Summary */}
           <div className="min-h-[5rem] rounded-[1.35rem] border border-white/8 bg-black/18 px-4 py-3">
             <div className="flex items-center justify-between">
-              <p className="font-mono text-xs text-[#f5f1ea]/70">Estado</p>
+              <p className="font-mono text-xs text-[#f5f1ea]/70">Estado Relevo</p>
               <span
                 className={`h-1.5 w-1.5 rounded-full ${
                   phase === "done"
@@ -633,10 +634,10 @@ function InteractiveChatUI() {
               />
             </div>
             <p className="mt-1.5 font-mono text-[11px] leading-5 text-white/40">
-              {phase === "idle" && "Esperando mensaje entrante…"}
-              {phase === "engine" && "Pipeline en ejecución — clasificando y extrayendo…"}
-              {phase === "typing" && "Componiendo respuesta con voice model…"}
-              {phase === "done" && "Flujo completado · respuesta entregada · cita confirmada"}
+              {phase === "idle" && "Esperando lead entrante para activar Relevo…"}
+              {phase === "engine" && "Relevo califica el lead, activa playbook y define el siguiente paso."}
+              {phase === "typing" && "Relevo compone la respuesta y empuja a una acción concreta."}
+              {phase === "done" && "Lead calificado · playbook ejecutado · siguiente paso empujado"}
             </p>
           </div>
         </div>
@@ -647,7 +648,7 @@ function InteractiveChatUI() {
         <div className="flex items-center justify-between gap-3 rounded-[1.3rem] border border-white/8 bg-black/20 px-4 py-3">
           <div className="min-w-0">
             <p className="text-[0.62rem] uppercase tracking-[0.24em] text-white/28">
-              Mensaje entrante
+              Lead entrante
             </p>
             <div className="mt-1 flex min-h-6 items-center gap-1 overflow-hidden">
               <span
@@ -690,11 +691,11 @@ export function ChatUI({ mode = "static" }: { mode?: ChatUIMode }) {
       <div className="flex items-center justify-between border-b border-white/6 px-5 py-4 sm:px-6">
         <div>
           <p className="text-[0.62rem] uppercase tracking-[0.34em] text-white/28">
-            Boreas Flow
+            Boreas OS
           </p>
           <div className="mt-2 flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-[#d4c0a1] shadow-[0_0_14px_rgba(212,192,161,0.5)]" />
-            <span className="text-sm text-[#f5f1ea]">Concierge activo</span>
+            <span className="text-sm text-[#f5f1ea]">Relevo · motor de conversión</span>
           </div>
         </div>
 
@@ -703,7 +704,7 @@ export function ChatUI({ mode = "static" }: { mode?: ChatUIMode }) {
             WhatsApp
           </span>
           <span className="rounded-full border border-white/8 px-3 py-1.5">
-            24/7
+            Playbook
           </span>
         </div>
       </div>

--- a/components/hero/header.tsx
+++ b/components/hero/header.tsx
@@ -1,9 +1,16 @@
 import Link from "next/link";
 
+const navLinks = [
+  { label: "Cómo funciona", href: "#como-funciona" },
+  { label: "Demo", href: "#demo-relevo" },
+  { label: "Sectores", href: "#sectores" },
+  { label: "Diagnóstico", href: "#diagnostico" },
+];
+
 export function Header() {
   return (
     <div className="sticky top-0 z-40 px-4 pt-4 sm:px-6 lg:px-10">
-      <div className="mx-auto flex w-full max-w-7xl items-center justify-between rounded-full border border-white/10 bg-black/25 px-4 py-3 shadow-[0_16px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl sm:px-6">
+      <div className="mx-auto flex w-full max-w-[1460px] items-center justify-between gap-6 rounded-full border border-white/10 bg-black/25 px-4 py-3 shadow-[0_16px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl sm:px-6">
         <Link
           href="/"
           className="flex items-center gap-3 text-[0.78rem] font-medium uppercase tracking-[0.28em] text-[#f5f1ea]/85 transition-colors duration-300 hover:text-[#f7f1ea]"
@@ -15,12 +22,34 @@ export function Header() {
           Boreas
         </Link>
 
-        <a
-          href="#diagnostico"
-          className="inline-flex items-center rounded-full border border-[#d4c0a1]/25 bg-white/[0.03] px-4 py-2.5 text-sm font-medium text-[#f7f1ea] transition-all duration-300 hover:border-[#d4c0a1]/45 hover:bg-white/[0.07]"
-        >
-          Recibir diagnóstico
-        </a>
+        <nav className="hidden items-center gap-6 text-sm text-white/56 lg:flex">
+          {navLinks.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="transition-colors duration-300 hover:text-white"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-3">
+          <a
+            href="#diagnostico"
+            className="hidden items-center rounded-full border border-white/14 bg-white/[0.03] px-4 py-2.5 text-sm font-medium text-[#f7f1ea] transition-all duration-300 hover:border-white/24 hover:bg-white/[0.07] sm:inline-flex"
+          >
+            Ver diagnóstico
+          </a>
+          <a
+            href="https://relevo.chat"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-full border border-[#d4c0a1]/25 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.1)_100%)] px-4 py-2.5 text-sm font-medium text-[#f7f1ea] transition-all duration-300 hover:border-[#d4c0a1]/45 hover:brightness-110"
+          >
+            Abrir Relevo
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/components/hero/header.tsx
+++ b/components/hero/header.tsx
@@ -16,10 +16,10 @@ export function Header() {
         </Link>
 
         <a
-          href="mailto:hola@boreas.ai"
+          href="#diagnostico"
           className="inline-flex items-center rounded-full border border-[#d4c0a1]/25 bg-white/[0.03] px-4 py-2.5 text-sm font-medium text-[#f7f1ea] transition-all duration-300 hover:border-[#d4c0a1]/45 hover:bg-white/[0.07]"
         >
-          Agendar llamada
+          Recibir diagnóstico
         </a>
       </div>
     </div>

--- a/components/hero/macbook-showcase.tsx
+++ b/components/hero/macbook-showcase.tsx
@@ -99,14 +99,16 @@ function MobileFrame({ children }: { children: React.ReactNode }) {
 }
 
 export function MacbookShowcase({
+  id,
   mode = "static",
 }: {
+  id?: string;
   mode?: "static" | "simulator";
 }) {
   const reduceMotion = useReducedMotion();
 
   return (
-    <div id="demo" className="relative mx-auto w-full max-w-[1080px] px-2 sm:px-4">
+    <div id={id} className="relative mx-auto w-full max-w-[1080px] px-2 sm:px-4">
       {/* Desktop: Full MacBook frame */}
       <div className="hidden lg:block">
         <MacbookFrame reduceMotion={reduceMotion}>

--- a/components/landing/bento-grid-section.tsx
+++ b/components/landing/bento-grid-section.tsx
@@ -9,13 +9,13 @@ export function BentoGridSection() {
 
   return (
     <SectionFrame>
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Sistema de decisión</SectionEyebrow>
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[48rem] lg:text-left">
+          <SectionEyebrow>Qué hace diferente a Relevo</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            La ventaja no es responder más.
+            La ventaja no es solo responder.
             <br className="hidden sm:block" />
-            Es responder con estructura.
+            Es responder con claridad y rumbo.
           </h2>
         </div>
 

--- a/components/landing/bento-grid-section.tsx
+++ b/components/landing/bento-grid-section.tsx
@@ -1,53 +1,73 @@
 "use client";
 
+import { playbookCards } from "@/content/boreas-home";
+
 import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
 export function BentoGridSection() {
+  const [primaryCard, sideCard, lowerLeftCard, lowerRightCard] = playbookCards;
+
   return (
     <SectionFrame>
       <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
         <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Capacidades</SectionEyebrow>
+          <SectionEyebrow>Sistema de decisión</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            Un consultor digital diseñado para que tú te enfoques en el servicio.
+            La ventaja no es responder más.
+            <br className="hidden sm:block" />
+            Es responder con estructura.
           </h2>
         </div>
 
         <div data-step-group className="mt-16 grid grid-cols-1 gap-5 md:grid-cols-3 md:grid-rows-[auto_auto]">
-          {/* Main Card */}
           <div data-step-card className="group relative col-span-1 flex flex-col overflow-hidden rounded-[2rem] border border-white/8 bg-white/[0.02] p-8 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm md:col-span-2 md:row-span-1">
             <div className="absolute inset-0 bg-gradient-to-br from-white/[0.04] to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
             <div className="relative z-10 flex flex-1 flex-col justify-center">
-              <h3 className="text-[1.7rem] font-medium leading-[1.08] tracking-[-0.04em] text-[#f7f1ea]">Respuesta Inteligente 24/7</h3>
+              <p className="text-[0.68rem] uppercase tracking-[0.34em] text-white/30">
+                {primaryCard.accent === "main" ? "Núcleo" : "Sistema"}
+              </p>
+              <h3 className="mt-6 text-[1.7rem] font-medium leading-[1.08] tracking-[-0.04em] text-[#f7f1ea]">
+                {primaryCard.title}
+              </h3>
               <p className="mt-4 max-w-md text-base leading-relaxed text-white/50">
-                Boreas no utiliza flujos de botones rígidos ni menús infinitos. Entiende la intención mediante lenguaje conversacional avanzado y responde de manera precisa y empática en segundos.
+                {primaryCard.description}
               </p>
             </div>
           </div>
 
-          {/* Tall Card */}
           <div data-step-card className="group relative col-span-1 flex flex-col overflow-hidden rounded-[2rem] border border-[#d8ccb2]/10 bg-[linear-gradient(180deg,rgba(216,204,178,0.03)_0%,rgba(216,204,178,0.01)_100%)] p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_24px_80px_rgba(0,0,0,0.2)] md:row-span-2">
             <div className="absolute top-0 right-0 h-40 w-40 -translate-y-8 translate-x-8 rounded-full bg-[#d8ccb2]/10 blur-[60px]" />
-            <div className="relative z-10 flex h-full flex-col justify-end min-h-[16rem]">
-              <h3 className="text-[1.7rem] font-medium leading-[1.08] tracking-[-0.04em] text-[#d8ccb2]">Cierre Integrado</h3>
+    <div className="relative z-10 flex h-full flex-col justify-end min-h-[16rem]">
+              <p className="text-[0.68rem] uppercase tracking-[0.34em] text-[#d8ccb2]/60">
+                Operación
+              </p>
+              <h3 className="mt-5 text-[1.7rem] font-medium leading-[1.08] tracking-[-0.04em] text-[#d8ccb2]">
+                {sideCard.title}
+              </h3>
               <p className="mt-4 text-base leading-relaxed text-[#d8ccb2]/70">
-                 Identifica tu disponibilidad en tiempo real, cruza los datos con la agenda y cierra reservaciones en automático, inyectándolas en tu sistema sin duplicidades.
+                {sideCard.description}
               </p>
             </div>
           </div>
 
-          {/* Small Card 1 */}
           <div data-step-card className="group relative col-span-1 flex flex-col justify-center overflow-hidden rounded-[2rem] border border-white/8 bg-white/[0.02] p-8 backdrop-blur-sm">
-             <div className="absolute inset-0 opacity-0 transition-opacity duration-500 bg-[radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.06),transparent_50%)] group-hover:opacity-100" />
-             <h3 className="text-xl font-medium tracking-tight text-[#f7f1ea]">Calificación Predictiva</h3>
-             <p className="mt-3 text-sm leading-relaxed text-white/50">Filtra clientes fríos y pre-cualifica a los prospectos genuinos pidiéndoles los datos obligatorios.</p>
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.06),transparent_50%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+            <h3 className="text-xl font-medium tracking-tight text-[#f7f1ea]">
+              {lowerLeftCard.title}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-white/50">
+              {lowerLeftCard.description}
+            </p>
           </div>
 
-          {/* Small Card 2 */}
           <div data-step-card className="group relative col-span-1 flex flex-col justify-center overflow-hidden rounded-[2rem] border border-white/8 bg-white/[0.02] p-8 backdrop-blur-sm">
-             <div className="absolute inset-0 opacity-0 transition-opacity duration-500 bg-[radial-gradient(circle_at_bottom_right,rgba(255,255,255,0.06),transparent_50%)] group-hover:opacity-100" />
-             <h3 className="text-xl font-medium tracking-tight text-[#f7f1ea]">Reactiva Conversaciones</h3>
-             <p className="mt-3 text-sm leading-relaxed text-white/50">Recupera leads olvidados con un seguimiento orgánico y sin fricciones diseñado para convertir.</p>
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(255,255,255,0.06),transparent_50%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+            <h3 className="text-xl font-medium tracking-tight text-[#f7f1ea]">
+              {lowerRightCard.title}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-white/50">
+              {lowerRightCard.description}
+            </p>
           </div>
         </div>
       </div>

--- a/components/landing/boreas-landing-sections.tsx
+++ b/components/landing/boreas-landing-sections.tsx
@@ -5,9 +5,9 @@ import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useRef } from "react";
 
+import { onboardingSteps, verticals } from "@/content/boreas-home";
 import { MacbookShowcase } from "@/components/hero/macbook-showcase";
 
-// Import modules (EPIC 4 & 5 & Re-designs)
 import { ProblemSection } from "./problem-section";
 import { MechanismSectionB } from "./mechanism-section-b";
 import { ComparisonSection } from "./comparison-section";
@@ -15,45 +15,10 @@ import { BentoGridSection } from "./bento-grid-section";
 import { FaqSection } from "./faq-section";
 import { GuaranteeSection } from "./guarantee-section";
 import { TrustAndProofSection } from "./trust-proof-section";
-import { FinalCtaSection } from "./final-cta-section";
+import { PlatformSystemSection } from "./platform-system-section";
+import { DiagnosticCtaSection } from "./diagnostic-cta-section";
 
 gsap.registerPlugin(useGSAP, ScrollTrigger);
-
-const steps = [
-  {
-    number: "01",
-    title: "Un cliente escribe",
-    description: "Desde WhatsApp, Instagram o cualquier canal donde llegue la intención.",
-  },
-  {
-    number: "02",
-    title: "Boreas responde",
-    description: "Aclara dudas, filtra al prospecto y propone horarios sin fricción.",
-  },
-  {
-    number: "03",
-    title: "La cita se agenda",
-    description: "La conversación avanza sola hasta la reserva, confirmación y seguimiento.",
-  },
-];
-
-const useCases = [
-  {
-    vertical: "Salud y Clínicas",
-    lead: "Pacientes con dudas o buscando agendar",
-    value: "Pacientes atendidos 24/7 sin colapsar la recepción. Boreas responde, filtra y agenda.",
-  },
-  {
-    vertical: "Inmobiliario y Construcción",
-    lead: "Prospectos interesados en propiedades o presupuestos",
-    value: "Calificación inmediata de leads fríos vs calientes. Captura de datos clave al instante.",
-  },
-  {
-    vertical: "Belleza y Bienestar",
-    lead: "Clientes buscando servicios y disponibilidad",
-    value: "Un recepcionista digital que no descansa. Cierra reservas mientras tú atiendes el negocio.",
-  },
-];
 
 export function SectionEyebrow({ children }: { children: React.ReactNode }) {
   return (
@@ -91,17 +56,23 @@ function HowItWorksSection() {
 
       <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
         <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Cómo funciona</SectionEyebrow>
+          <SectionEyebrow>Onboarding</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            Tres movimientos precisos para que una conversación termine en cita.
+            El negocio aporta contexto.
+            <br className="hidden sm:block" />
+            Boreas pone la estructura.
           </h2>
+          <p className="mt-6 text-lg text-white/50">
+            El onboarding está diseñado para generar confianza y velocidad. No hace falta construir
+            un flujo desde cero ni aprender a prompting.
+          </p>
         </div>
 
         <div
           data-step-group
-          className="mt-14 grid gap-4 lg:grid-cols-3 lg:gap-5"
+          className="mt-14 grid gap-4 md:grid-cols-2 xl:grid-cols-4 xl:gap-5"
         >
-          {steps.map((step) => (
+          {onboardingSteps.map((step) => (
             <article
               key={step.number}
               data-step-card
@@ -154,12 +125,18 @@ function VisualSection() {
         className="pointer-events-none absolute left-1/2 top-20 h-96 w-[44rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.08),transparent_68%)] blur-[120px]"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-4xl text-center">
-          <SectionEyebrow>En acción</SectionEyebrow>
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mx-auto max-w-4xl text-center">
+          <SectionEyebrow>Relevo en acción</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.9vw,4.2rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
-            Así se ve cuando alguien sí está trabajando por ti 24/7.
+            Así se ve cuando la intención
+            <br className="hidden sm:block" />
+            se empuja a un siguiente paso real.
           </h2>
+          <p className="mt-6 text-lg text-white/50">
+            La demo no muestra un chat genérico. Muestra a Relevo calificando y llevando la
+            conversación a una acción concreta.
+          </p>
         </div>
 
         <div
@@ -186,17 +163,23 @@ function UseCasesSection() {
 
       <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
         <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Casos de uso</SectionEyebrow>
+          <SectionEyebrow>Verticales activas</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            Diseñado para negocios donde cada mensaje importa.
+            Tres industrias, una tesis:
+            <br className="hidden sm:block" />
+            convertir intención con playbooks.
           </h2>
+          <p className="mt-6 text-lg text-white/50">
+            Salud, belleza e inmobiliario comparten el problema de respuesta y seguimiento, pero
+            cada una necesita preguntas, filtros y cierres distintos.
+          </p>
         </div>
 
         <div
           data-step-group
           className="mt-14 grid gap-4 lg:grid-cols-3 lg:gap-5"
         >
-          {useCases.map((useCase) => (
+          {verticals.map((useCase) => (
             <article
               key={useCase.vertical}
               data-step-card
@@ -208,12 +191,16 @@ function UseCasesSection() {
               </p>
               <div className="mt-8 flex flex-col gap-5">
                 <div>
-                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Escenario</h4>
-                  <p className="mt-1 text-base leading-snug text-[#f7f1ea]">{useCase.lead}</p>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Fuga principal</h4>
+                  <p className="mt-1 text-base leading-snug text-[#f7f1ea]">{useCase.pain}</p>
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Boreas</h4>
-                  <p className="mt-1 text-base leading-snug text-white/56">{useCase.value}</p>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Lead típico</h4>
+                  <p className="mt-1 text-base leading-snug text-white/56">{useCase.lead}</p>
+                </div>
+                <div>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Acción objetivo</h4>
+                  <p className="mt-1 text-base leading-snug text-white/56">{useCase.action}</p>
                 </div>
               </div>
             </article>
@@ -377,17 +364,18 @@ export function BoreasLandingSections() {
 
   return (
     <div ref={scopeRef} className="relative overflow-clip bg-[#0e1114] text-[#f5f1ea]">
+      <PlatformSystemSection />
       <ProblemSection />
-      <MechanismSectionB />
       <ComparisonSection />
+      <MechanismSectionB />
       <BentoGridSection />
-      <HowItWorksSection />
       <VisualSection />
       <UseCasesSection />
+      <HowItWorksSection />
       <TrustAndProofSection />
       <GuaranteeSection />
       <FaqSection />
-      <FinalCtaSection />
+      <DiagnosticCtaSection />
     </div>
   );
 }

--- a/components/landing/boreas-landing-sections.tsx
+++ b/components/landing/boreas-landing-sections.tsx
@@ -31,14 +31,17 @@ export function SectionEyebrow({ children }: { children: React.ReactNode }) {
 export function SectionFrame({
   children,
   className = "",
+  id,
 }: {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }) {
   return (
     <section
+      id={id}
       data-parallax-section
-      className={`relative overflow-hidden py-28 sm:py-36 ${className}`}
+      className={`relative scroll-mt-28 overflow-hidden py-28 sm:py-36 ${className}`}
     >
       {children}
     </section>
@@ -47,24 +50,24 @@ export function SectionFrame({
 
 function HowItWorksSection() {
   return (
-    <SectionFrame>
+    <SectionFrame id="implementacion">
       <div
         data-parallax
         data-depth="12"
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Onboarding</SectionEyebrow>
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[48rem] lg:text-left">
+          <SectionEyebrow>Puesta en marcha</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            El negocio aporta contexto.
+            Tú compartes lo básico.
             <br className="hidden sm:block" />
-            Boreas pone la estructura.
+            Boreas organiza el resto.
           </h2>
           <p className="mt-6 text-lg text-white/50">
-            El onboarding está diseñado para generar confianza y velocidad. No hace falta construir
-            un flujo desde cero ni aprender a prompting.
+            La idea es que puedas empezar rápido, con claridad y sin diseñar flujos complejos desde
+            cero.
           </p>
         </div>
 
@@ -97,55 +100,30 @@ function HowItWorksSection() {
 }
 
 function VisualSection() {
-  const visualRef = useRef<HTMLDivElement>(null);
-
-  useGSAP(
-    () => {
-      const secondaryShowcase = visualRef.current?.querySelector<HTMLElement>("#demo");
-      const previousId = secondaryShowcase?.id;
-
-      if (secondaryShowcase) {
-        secondaryShowcase.id = "demo-visual";
-      }
-
-      return () => {
-        if (secondaryShowcase && previousId) {
-          secondaryShowcase.id = previousId;
-        }
-      };
-    },
-    { scope: visualRef },
-  );
-
   return (
-    <SectionFrame className="pb-20 sm:pb-28">
+    <SectionFrame id="demo-relevo" className="pb-20 sm:pb-28">
       <div
         data-parallax
         data-depth="18"
         className="pointer-events-none absolute left-1/2 top-20 h-96 w-[44rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.08),transparent_68%)] blur-[120px]"
       />
 
-        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-          <div data-reveal className="mx-auto max-w-4xl text-center">
+        <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[48rem] lg:text-left">
           <SectionEyebrow>Relevo en acción</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.9vw,4.2rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
-            Así se ve cuando la intención
+            Así se ve cuando una conversación
             <br className="hidden sm:block" />
-            se empuja a un siguiente paso real.
+            sí avanza a algo concreto.
           </h2>
           <p className="mt-6 text-lg text-white/50">
-            La demo no muestra un chat genérico. Muestra a Relevo calificando y llevando la
-            conversación a una acción concreta.
+            No es un chat decorativo. Es una muestra de cómo Relevo responde, orienta y propone el
+            siguiente paso.
           </p>
         </div>
 
-        <div
-          ref={visualRef}
-          data-reveal
-          data-visual-device
-          className="mt-16 sm:mt-20"
-        >
-          <MacbookShowcase mode="simulator" />
+        <div data-reveal data-visual-device className="mt-16 sm:mt-20">
+          <MacbookShowcase id="demo-visual" mode="simulator" />
         </div>
       </div>
     </SectionFrame>
@@ -154,24 +132,24 @@ function VisualSection() {
 
 function UseCasesSection() {
   return (
-    <SectionFrame>
+    <SectionFrame id="sectores">
       <div
         data-parallax
         data-depth="16"
         className="pointer-events-none absolute left-[8%] top-12 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.06),transparent_68%)] blur-[120px]"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Verticales activas</SectionEyebrow>
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[48rem] lg:text-left">
+          <SectionEyebrow>Sectores</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            Tres industrias, una tesis:
+            Tres sectores, el mismo problema:
             <br className="hidden sm:block" />
-            convertir intención con playbooks.
+            mensajes que se enfrían por falta de atención.
           </h2>
           <p className="mt-6 text-lg text-white/50">
-            Salud, belleza e inmobiliario comparten el problema de respuesta y seguimiento, pero
-            cada una necesita preguntas, filtros y cierres distintos.
+            Salud, belleza e inmobiliario necesitan rapidez y seguimiento, pero cada uno pide una
+            manera distinta de orientar la conversación.
           </p>
         </div>
 
@@ -191,15 +169,15 @@ function UseCasesSection() {
               </p>
               <div className="mt-8 flex flex-col gap-5">
                 <div>
-                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Fuga principal</h4>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Lo que hoy se pierde</h4>
                   <p className="mt-1 text-base leading-snug text-[#f7f1ea]">{useCase.pain}</p>
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Lead típico</h4>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Consulta típica</h4>
                   <p className="mt-1 text-base leading-snug text-white/56">{useCase.lead}</p>
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Acción objetivo</h4>
+                  <h4 className="text-sm font-medium tracking-wide text-[#d8ccb2]">Meta de la conversación</h4>
                   <p className="mt-1 text-base leading-snug text-white/56">{useCase.action}</p>
                 </div>
               </div>

--- a/components/landing/comparison-section.tsx
+++ b/components/landing/comparison-section.tsx
@@ -1,42 +1,32 @@
 "use client";
 
+import { comparisonFlows } from "@/content/boreas-home";
+
 import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
-
-const manualFlow = [
-  "Notificación ignorada por horas",
-  "Respuestas manuales e intermitentes",
-  "El cliente pierde interés y cotiza en otro lado",
-  "0% de Cierre, tiempo y dinero desperdiciado",
-];
-
-const boreasFlow = [
-  "Respuesta instantánea (menos de 1 minuto)",
-  "Calificación inteligente de la intención",
-  "Aclaración de dudas y propuesta de opciones",
-  "100% Atención, paciente o prospecto capturado",
-];
 
 export function ComparisonSection() {
   return (
     <SectionFrame>
       <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
         <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>El problema real</SectionEyebrow>
+          <SectionEyebrow>Conversión estructurada</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            El verdadero costo de responder tarde.
+            La diferencia no está en contestar.
+            <br className="hidden sm:block" />
+            Está en cómo la conversación avanza.
           </h2>
           <p className="mt-6 text-lg text-white/50">
-            Cada vez que un lead espera respuesta, la intención de compra se erosiona y tu CAC aumenta.
+            Cuando la atención depende de reacción manual, la intención se enfría. Cuando entra en
+            un sistema, cada paso empuja al lead hacia una acción concreta.
           </p>
         </div>
 
         <div data-reveal className="mt-16 grid gap-6 lg:grid-cols-2 lg:gap-10">
-          {/* Manual Flow */}
           <div className="relative flex flex-col rounded-[2rem] border border-white/5 bg-gradient-to-b from-[#1a1111]/80 to-[#0e1114] p-8 sm:p-12">
             <div className="absolute top-0 right-0 h-48 w-48 -translate-y-12 translate-x-12 rounded-full bg-red-500/5 blur-[80px] pointer-events-none" />
-            <h3 className="text-xl font-medium tracking-tight text-white/40">El ciclo habitual (Manual)</h3>
+            <h3 className="text-xl font-medium tracking-tight text-white/40">Sin sistema</h3>
             <div className="relative z-10 mt-10 flex flex-col gap-6">
-              {manualFlow.map((step, idx) => (
+              {comparisonFlows.manual.map((step, idx) => (
                 <div key={idx} className="flex items-start gap-4">
                   <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-red-500/[0.08] text-xs font-bold text-red-500/40">
                     ✕
@@ -47,12 +37,13 @@ export function ComparisonSection() {
             </div>
           </div>
 
-          {/* Boreas Flow */}
           <div className="relative flex flex-col rounded-[2rem] border border-[#d8ccb2]/20 bg-gradient-to-b from-[#1a1814]/90 to-[#0e1114] p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_24px_80px_rgba(0,0,0,0.12)] sm:p-12 backdrop-blur-md">
             <div className="absolute top-0 right-0 h-56 w-56 -translate-y-12 translate-x-12 rounded-full bg-[#d8ccb2]/10 blur-[90px] pointer-events-none" />
-            <h3 className="relative z-10 text-xl font-medium tracking-tight text-[#d8ccb2]">El ciclo Boreas</h3>
+            <h3 className="relative z-10 text-xl font-medium tracking-tight text-[#d8ccb2]">
+              Con Relevo
+            </h3>
             <div className="relative z-10 mt-10 flex flex-col gap-6">
-              {boreasFlow.map((step, idx) => (
+              {comparisonFlows.relevo.map((step, idx) => (
                 <div key={idx} className="flex items-start gap-4">
                   <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#d8ccb2]/10 text-xs font-bold text-[#d8ccb2] shadow-[0_0_12px_rgba(216,204,178,0.2)]">
                     ✓
@@ -61,12 +52,15 @@ export function ComparisonSection() {
                 </div>
               ))}
             </div>
-            
-            <div className="relative z-10 mt-10 pt-8 border-t border-white/5">
-               <a href="mailto:hola@boreas.ai" className="inline-flex w-max items-center text-sm font-medium text-[#d8ccb2] hover:text-white transition-colors">
-                  Descubre la diferencia
-                  <span className="ml-2">→</span>
-               </a>
+
+            <div className="relative z-10 mt-10 border-t border-white/5 pt-8">
+              <a
+                href="#diagnostico"
+                className="inline-flex w-max items-center text-sm font-medium text-[#d8ccb2] transition-colors hover:text-white"
+              >
+                Ver cuál playbook te conviene primero
+                <span className="ml-2">→</span>
+              </a>
             </div>
           </div>
         </div>

--- a/components/landing/comparison-section.tsx
+++ b/components/landing/comparison-section.tsx
@@ -7,24 +7,24 @@ import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 export function ComparisonSection() {
   return (
     <SectionFrame>
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow>Conversión estructurada</SectionEyebrow>
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[48rem] lg:text-left">
+          <SectionEyebrow>La diferencia real</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
             La diferencia no está en contestar.
             <br className="hidden sm:block" />
             Está en cómo la conversación avanza.
           </h2>
           <p className="mt-6 text-lg text-white/50">
-            Cuando la atención depende de reacción manual, la intención se enfría. Cuando entra en
-            un sistema, cada paso empuja al lead hacia una acción concreta.
+            Cuando la atención depende solo del equipo, muchas conversaciones se quedan a medias.
+            Cuando entra Relevo, cada respuesta busca mover a la persona hacia algo concreto.
           </p>
         </div>
 
         <div data-reveal className="mt-16 grid gap-6 lg:grid-cols-2 lg:gap-10">
           <div className="relative flex flex-col rounded-[2rem] border border-white/5 bg-gradient-to-b from-[#1a1111]/80 to-[#0e1114] p-8 sm:p-12">
             <div className="absolute top-0 right-0 h-48 w-48 -translate-y-12 translate-x-12 rounded-full bg-red-500/5 blur-[80px] pointer-events-none" />
-            <h3 className="text-xl font-medium tracking-tight text-white/40">Sin sistema</h3>
+            <h3 className="text-xl font-medium tracking-tight text-white/40">Sin atención constante</h3>
             <div className="relative z-10 mt-10 flex flex-col gap-6">
               {comparisonFlows.manual.map((step, idx) => (
                 <div key={idx} className="flex items-start gap-4">
@@ -58,7 +58,7 @@ export function ComparisonSection() {
                 href="#diagnostico"
                 className="inline-flex w-max items-center text-sm font-medium text-[#d8ccb2] transition-colors hover:text-white"
               >
-                Ver cuál playbook te conviene primero
+                Ver por dónde empezar
                 <span className="ml-2">→</span>
               </a>
             </div>

--- a/components/landing/diagnostic-cta-section.tsx
+++ b/components/landing/diagnostic-cta-section.tsx
@@ -1,0 +1,20 @@
+import { DiagnosticCtaForm } from "@/components/analytics/diagnostic-cta-form";
+
+export function DiagnosticCtaSection() {
+  return (
+    <section id="diagnostico" className="relative overflow-hidden py-28 sm:py-36">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-10 h-[28rem] w-[52rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.12),transparent_72%)] blur-[135px]"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
+      />
+
+      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+        <DiagnosticCtaForm />
+      </div>
+    </section>
+  );
+}

--- a/components/landing/diagnostic-cta-section.tsx
+++ b/components/landing/diagnostic-cta-section.tsx
@@ -2,7 +2,7 @@ import { DiagnosticCtaForm } from "@/components/analytics/diagnostic-cta-form";
 
 export function DiagnosticCtaSection() {
   return (
-    <section id="diagnostico" className="relative overflow-hidden py-28 sm:py-36">
+    <section id="diagnostico" className="relative scroll-mt-28 overflow-hidden py-28 sm:py-36">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute left-1/2 top-10 h-[28rem] w-[52rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.12),transparent_72%)] blur-[135px]"
@@ -12,7 +12,7 @@ export function DiagnosticCtaSection() {
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
         <DiagnosticCtaForm />
       </div>
     </section>

--- a/components/landing/faq-section.tsx
+++ b/components/landing/faq-section.tsx
@@ -3,30 +3,10 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { useState } from "react";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
-const faqs = [
-  {
-    question: "¿En qué canales funciona Boreas?",
-    answer: "Principalmente en WhatsApp e Instagram, que son los canales de mayor intención y comunicación directa. Boreas interviene sin entorpecer el flujo humano, de tal forma que tú o tu equipo siempre pueden visualizar la conversación y tomar el control si lo desean."
-  },
-  {
-    question: "¿Se conecta con mi sistema de agenda, CRM o historia clïnica?",
-    answer: "Traspasa de forma nativa los datos acordados y puede sincronizarse con las agendas más modernas del mercado. Nos aseguramos de mantener un mapeo bidireccional para que en tu calendario humano nunca haya choques ni sobreocupación."
-  },
-  {
-    question: "¿Suena a bot robotizado o con menús inflexibles?",
-    answer: "Absolutamente no. Está entrenado para entender el contexto humano, interpretar notas de voz, empatizar con objeciones y responder con fluidez conversacional idéntica a la del mejor ejecutivo de cuenta de tu negocio."
-  },
-  {
-    question: "¿Boreas está diseñado para empresas Enterprise o sirve para Pymes?",
-    answer: "Es apto para cualquier negocio (Clínicas, Consultorios, Corredores inmobiliarios, Pymes, Agencias) que pierda ingresos, clientes o reservas debido a la demora natural de un equipo humano que no puede responder 24/7."
-  },
-  {
-    question: "¿Qué pasa si un cliente tiene un problema muy complejo y requiere un humano?",
-    answer: "Boreas identifica automáticamente los límites de su alcance y el estado emocional del cliente. Captura todo el contexto, lo unifica en un perfil y notifica a tu equipo silenciosamente para que un humano experto lo retome sin interrupciones."
-  }
-];
+import { faqs } from "@/content/boreas-home";
+
+import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
 export function FaqSection() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -41,12 +21,12 @@ export function FaqSection() {
   };
 
   return (
-    <SectionFrame>
-      <div className="relative mx-auto max-w-3xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mb-14 text-center">
-          <SectionEyebrow>FAQ</SectionEyebrow>
+      <SectionFrame>
+        <div className="relative mx-auto max-w-3xl px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mb-14 text-center">
+            <SectionEyebrow>FAQ</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
-            Transparencia total.
+            Lo importante está claro desde el inicio.
           </h2>
         </div>
 

--- a/components/landing/faq-section.tsx
+++ b/components/landing/faq-section.tsx
@@ -22,15 +22,15 @@ export function FaqSection() {
 
   return (
       <SectionFrame>
-        <div className="relative mx-auto max-w-3xl px-4 sm:px-6 lg:px-10">
-          <div data-reveal className="mb-14 text-center">
+        <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mb-14 text-center lg:max-w-[48rem] lg:text-left">
             <SectionEyebrow>FAQ</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.1rem,4.6vw,4rem)] font-medium leading-[1.06] tracking-[-0.052em] text-[#f7f1ea]">
             Lo importante está claro desde el inicio.
           </h2>
         </div>
 
-        <div data-reveal className="mx-auto flex w-full flex-col gap-4">
+        <div data-reveal className="mx-auto flex w-full max-w-[52rem] flex-col gap-4 lg:mr-0 lg:ml-auto">
           {faqs.map((faq, index) => {
             const isOpen = openIndex === index;
             return (

--- a/components/landing/final-cta-section.tsx
+++ b/components/landing/final-cta-section.tsx
@@ -23,10 +23,10 @@ export function FinalCtaSection() {
           <p className="mt-6 text-lg text-white/50">Automatiza la calificación y las reservas desde hoy. Desplegable en 24h.</p>
 
           <a
-            href="mailto:hola@boreas.ai"
+            href="#diagnostico"
             className="mt-12 inline-flex items-center justify-center rounded-full border border-white/14 bg-[linear-gradient(180deg,rgba(216,204,178,0.22)_0%,rgba(216,204,178,0.12)_100%)] px-10 py-5 text-[1.1rem] font-medium text-[#fbfcfd] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(0,0,0,0.08),0_18px_44px_rgba(0,0,0,0.25)] backdrop-blur-xl transition-all duration-300 hover:scale-[1.02] hover:border-[#d8ccb2]/30"
           >
-            Agendar llamada
+            Recibir diagnóstico
           </a>
         </div>
       </div>

--- a/components/landing/guarantee-section.tsx
+++ b/components/landing/guarantee-section.tsx
@@ -5,7 +5,7 @@ import { SectionFrame } from "./boreas-landing-sections";
 export function GuaranteeSection() {
   return (
     <SectionFrame className="py-20 sm:py-32">
-      <div className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-10">
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
         <div data-reveal className="relative overflow-hidden rounded-[2.5rem] border border-[#d8ccb2]/15 bg-[linear-gradient(180deg,rgba(216,204,178,0.06)_0%,rgba(216,204,178,0.01)_100%)] px-8 py-16 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_80px_rgba(0,0,0,0.3)] md:px-20 md:py-24 backdrop-blur-md">
           {/* Subtle Glows */}
           <div className="absolute left-1/2 top-0 h-56 w-[70%] -translate-x-1/2 rounded-full bg-[#d8ccb2]/10 blur-[80px] pointer-events-none" />
@@ -20,9 +20,9 @@ export function GuaranteeSection() {
               </h2>
 
               <p className="mt-8 max-w-2xl text-lg leading-relaxed text-[#f7f1ea]/60">
-                El negocio no tiene que inventar la lógica conversacional ni entrenar un bot desde
-                cero. En v2.1 solo comparte sus datos operativos, y Boreas activa el playbook
-                correcto para que Relevo arranque con estructura, supervisión y criterios medibles.
+                Tu equipo no tiene que inventar cada respuesta ni armar flujos complejos desde
+                cero. Compartes la información clave del negocio y Boreas deja a Relevo listo para
+                atender con orden, claridad y seguimiento.
               </p>
 
               <a

--- a/components/landing/guarantee-section.tsx
+++ b/components/landing/guarantee-section.tsx
@@ -10,24 +10,26 @@ export function GuaranteeSection() {
           {/* Subtle Glows */}
           <div className="absolute left-1/2 top-0 h-56 w-[70%] -translate-x-1/2 rounded-full bg-[#d8ccb2]/10 blur-[80px] pointer-events-none" />
           
-          <div className="relative z-10 flex flex-col items-center">
-             <div className="mb-8 flex h-16 w-16 items-center justify-center rounded-full bg-[#d8ccb2]/10 shadow-[0_0_32px_rgba(216,204,178,0.15)] ring-1 ring-[#d8ccb2]/20">
-               <span className="text-2xl text-[#d8ccb2]">✦</span>
-             </div>
-             
-             <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-medium leading-[1.05] tracking-[-0.04em] text-[#f7f1ea] max-w-2xl">
-               Implementación supervisada, cero dolores de cabeza.
-             </h2>
-             
-             <p className="mt-8 max-w-2xl text-lg leading-relaxed text-[#f7f1ea]/60">
-               Sabemos que adoptar IA genera fricción. Por eso desplegamos a Boreas en tus canales oficiales bajo nuestra supervisión total. Lo entrenamos con la identidad de tu marca, ajustamos todos sus parámetros y realizamos acompañamiento estricto para asegurar que tu calidad de servicio humano jamás se perciba vulnerada.
-             </p>
-             
-             <a
-                href="mailto:hola@boreas.ai"
+            <div className="relative z-10 flex flex-col items-center">
+              <div className="mb-8 flex h-16 w-16 items-center justify-center rounded-full bg-[#d8ccb2]/10 shadow-[0_0_32px_rgba(216,204,178,0.15)] ring-1 ring-[#d8ccb2]/20">
+                <span className="text-2xl text-[#d8ccb2]">✦</span>
+              </div>
+
+              <h2 className="max-w-2xl text-[clamp(2rem,4vw,3.5rem)] font-medium leading-[1.05] tracking-[-0.04em] text-[#f7f1ea]">
+                Onboarding guiado, controlado y sin improvisar.
+              </h2>
+
+              <p className="mt-8 max-w-2xl text-lg leading-relaxed text-[#f7f1ea]/60">
+                El negocio no tiene que inventar la lógica conversacional ni entrenar un bot desde
+                cero. En v2.1 solo comparte sus datos operativos, y Boreas activa el playbook
+                correcto para que Relevo arranque con estructura, supervisión y criterios medibles.
+              </p>
+
+              <a
+                href="#diagnostico"
                 className="mt-12 inline-flex min-w-[13rem] items-center justify-center rounded-full border border-[#d8ccb2]/20 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.12)_100%)] px-6 py-4 text-base font-medium text-[#fbfcfd] shadow-[0_14px_34px_rgba(0,0,0,0.2)] transition-all hover:scale-[1.02] hover:border-[#d8ccb2]/30 hover:brightness-110"
               >
-                Garantizar mi reserva 
+                Recibir diagnóstico
               </a>
           </div>
         </div>

--- a/components/landing/mechanism-section-b.tsx
+++ b/components/landing/mechanism-section-b.tsx
@@ -10,17 +10,17 @@ export function MechanismSectionB() {
   return (
     <div className="relative bg-transparent">
       <SectionFrame className="border-b border-[#d8ccb2]/10 py-24 sm:py-36">
-        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-          <div data-reveal className="mx-auto max-w-4xl text-center">
-            <SectionEyebrow>Playbooks</SectionEyebrow>
+        <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[50rem] lg:text-left">
+            <SectionEyebrow>Cómo responde Relevo</SectionEyebrow>
             <h2 className="mt-8 text-balance text-[clamp(2.4rem,5vw,4.5rem)] font-medium leading-[1.04] tracking-[-0.05em] text-[#f7f1ea]">
-              Relevo no improvisa prompts.
+              Relevo no responde al azar.
               <br className="hidden sm:block" />
-              <span className="text-white/60">Ejecuta una lógica completa de conversación.</span>
+              <span className="text-white/60">Sigue una guía clara para ayudar a avanzar.</span>
             </h2>
-            <p className="mx-auto mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg">
-              Cada playbook define la secuencia exacta para abrir, calificar, reducir fricción,
-              empujar a una acción y cerrar con contexto. Eso es lo que hace consistente el sistema.
+            <p className="mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg lg:mx-0">
+              Detrás de cada respuesta hay una secuencia pensada para entender mejor, resolver dudas
+              y proponer el siguiente paso en el momento correcto.
             </p>
           </div>
 

--- a/components/landing/mechanism-section-b.tsx
+++ b/components/landing/mechanism-section-b.tsx
@@ -1,71 +1,74 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
-const nodes = [
-  { step: "Responde", desc: "Contesta al instante usando el tono exacto de tu negocio." },
-  { step: "Califica", desc: "Hace las preguntas clave para saber si es un prospecto real." },
-  { step: "Sigue", desc: "Retoma a los que te dejaron en visto, sin parecer desesperado." },
-  { step: "Cierra", desc: "Agenda la cita directo en tu calendario sin que tú muevas un dedo." },
-];
+import { playbookPhases } from "@/content/boreas-home";
+
+import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
 export function MechanismSectionB() {
   return (
     <div className="relative bg-transparent">
-       <SectionFrame className="py-24 sm:py-36 border-b border-[#d8ccb2]/10">
-         <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-           <div data-reveal className="mx-auto max-w-4xl text-center">
-             <SectionEyebrow>Mecanismo</SectionEyebrow>
-             <h2 className="mt-8 text-balance text-[clamp(2.4rem,5vw,4.5rem)] font-medium leading-[1.04] tracking-[-0.05em] text-[#f7f1ea]">
-                No necesitas más mensajes,<br className="hidden sm:block"/>
-                <span className="text-white/60">necesitas quien los responda.</span>
-             </h2>
-           </div>
+      <SectionFrame className="border-b border-[#d8ccb2]/10 py-24 sm:py-36">
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+          <div data-reveal className="mx-auto max-w-4xl text-center">
+            <SectionEyebrow>Playbooks</SectionEyebrow>
+            <h2 className="mt-8 text-balance text-[clamp(2.4rem,5vw,4.5rem)] font-medium leading-[1.04] tracking-[-0.05em] text-[#f7f1ea]">
+              Relevo no improvisa prompts.
+              <br className="hidden sm:block" />
+              <span className="text-white/60">Ejecuta una lógica completa de conversación.</span>
+            </h2>
+            <p className="mx-auto mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg">
+              Cada playbook define la secuencia exacta para abrir, calificar, reducir fricción,
+              empujar a una acción y cerrar con contexto. Eso es lo que hace consistente el sistema.
+            </p>
+          </div>
 
-           <div className="relative mt-24">
-             {/* Progress Track Background Desktop */}
-             <div className="absolute left-0 top-[20px] hidden h-[1px] w-full bg-white/10 md:block" />
-             
-             {/* Animated Progress Line */}
-             <motion.div 
-               initial={{ width: "0%" }}
-               whileInView={{ width: "100%" }}
-               viewport={{ once: true, margin: "-100px" }}
-               transition={{ duration: 3.2, ease: "easeInOut" }}
-               className="absolute left-0 top-[19px] hidden h-[3px] bg-gradient-to-r from-transparent via-[#d8ccb2]/90 to-transparent md:block shadow-[0_0_15px_rgba(216,204,178,0.5)] rounded-full" 
-               style={{ transformOrigin: "left center" }}
-             />
+          <div className="relative mt-24">
+            <div className="absolute left-0 top-[20px] hidden h-[1px] w-full bg-white/10 md:block" />
 
-             <div className="relative z-10 grid gap-10 md:grid-cols-4 md:gap-6 px-2">
-                {nodes.map((node, index) => {
+            <motion.div
+              initial={{ width: "0%" }}
+              whileInView={{ width: "100%" }}
+              viewport={{ once: true, margin: "-100px" }}
+              transition={{ duration: 3.2, ease: "easeInOut" }}
+              className="absolute left-0 top-[19px] hidden h-[3px] rounded-full bg-gradient-to-r from-transparent via-[#d8ccb2]/90 to-transparent shadow-[0_0_15px_rgba(216,204,178,0.5)] md:block"
+              style={{ transformOrigin: "left center" }}
+            />
+
+            <div className="relative z-10 grid gap-10 px-2 md:grid-cols-5 md:gap-6">
+              {playbookPhases.map((node, index) => {
                   return (
-                    <motion.div 
+                    <motion.div
                       key={index}
                       initial={{ opacity: 0, y: 20 }}
                       whileInView={{ opacity: 1, y: 0 }}
                       viewport={{ once: true, margin: "-100px" }}
-                      transition={{ duration: 0.8, delay: 0.4 + (index * 0.6) }} /* Synchronize with the slower line sweep */
+                      transition={{ duration: 0.8, delay: 0.4 + index * 0.4 }}
                       className="flex flex-col items-center text-center md:items-start md:text-left"
                     >
-                      {/* Node Dot Desktop */}
                       <div className="hidden md:flex mb-6 h-10 w-10 items-center justify-center rounded-full border-[2px] border-[#0e1114] bg-[#1a1c1e] shadow-[0_0_0_1px_rgba(255,255,255,0.15)] transition-all">
                         <div className="h-2 w-2 rounded-full bg-[#d8ccb2] shadow-[0_0_12px_rgba(216,204,178,0.9)]" />
                       </div>
-                      
-                      {/* Node Dot Mobile */}
+
                       <div className="mb-4 flex h-3 w-3 md:hidden rounded-full bg-[#d8ccb2] shadow-[0_0_10px_rgba(216,204,178,0.8)]" />
 
-                      <p className="text-xs uppercase tracking-widest text-[#d8ccb2]/60 font-semibold mb-2">0{index + 1}</p>
-                      <h4 className="text-[1.3rem] font-medium tracking-tight text-[#f7f1ea]">{node.step}</h4>
-                      <p className="mt-3 text-[15px] leading-relaxed text-white/50">{node.desc}</p>
+                      <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-[#d8ccb2]/60">
+                        {node.number}
+                      </p>
+                      <h4 className="text-[1.3rem] font-medium tracking-tight text-[#f7f1ea]">
+                        {node.title}
+                      </h4>
+                      <p className="mt-3 text-[15px] leading-relaxed text-white/50">
+                        {node.description}
+                      </p>
                     </motion.div>
                   );
                 })}
-             </div>
-           </div>
-         </div>
-       </SectionFrame>
+            </div>
+          </div>
+        </div>
+      </SectionFrame>
     </div>
   );
 }

--- a/components/landing/platform-system-section.tsx
+++ b/components/landing/platform-system-section.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { platformLayers } from "@/content/boreas-home";
+
+import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
+
+export function PlatformSystemSection() {
+  return (
+    <SectionFrame className="pt-8 sm:pt-14">
+      <div
+        data-parallax
+        data-depth="12"
+        className="pointer-events-none absolute right-[10%] top-10 h-80 w-80 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.08),transparent_70%)] blur-[120px]"
+      />
+
+      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center">
+          <SectionEyebrow>Arquitectura Boreas</SectionEyebrow>
+          <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.8vw,4.25rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
+            Boreas organiza revenue como sistema.
+            <br className="hidden sm:block" />
+            Relevo es la capa activa hoy.
+          </h2>
+          <p className="mx-auto mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg">
+            No vendemos piezas sueltas. Boreas ordena adquisición, conversión y retención como un
+            sistema operativo. En v2.1 el foco absoluto está en conversión, porque esa es la capa
+            que hoy genera resultados medibles más rápido.
+          </p>
+        </div>
+
+        <div data-step-group className="mt-14 grid gap-4 lg:grid-cols-3 lg:gap-5">
+          {platformLayers.map((layer) => (
+            <article
+              key={layer.title}
+              data-step-card
+              className="relative overflow-hidden rounded-[2rem] border border-white/8 bg-white/[0.03] p-7 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm"
+            >
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/16 to-transparent" />
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[1.45rem] font-medium tracking-[-0.04em] text-[#f7f1ea]">
+                  {layer.title}
+                </p>
+                <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[0.62rem] uppercase tracking-[0.24em] text-[#d8ccb2]">
+                  {layer.status}
+                </span>
+              </div>
+              <p className="mt-5 text-base leading-7 text-white/56">{layer.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </SectionFrame>
+  );
+}

--- a/components/landing/platform-system-section.tsx
+++ b/components/landing/platform-system-section.tsx
@@ -6,25 +6,24 @@ import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
 export function PlatformSystemSection() {
   return (
-    <SectionFrame className="pt-8 sm:pt-14">
+    <SectionFrame id="como-funciona" className="pt-8 sm:pt-14">
       <div
         data-parallax
         data-depth="12"
         className="pointer-events-none absolute right-[10%] top-10 h-80 w-80 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.08),transparent_70%)] blur-[120px]"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
-        <div data-reveal className="mx-auto max-w-4xl text-center">
-          <SectionEyebrow>Arquitectura Boreas</SectionEyebrow>
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
+        <div data-reveal className="mx-auto max-w-4xl text-center lg:mx-0 lg:max-w-[50rem] lg:text-left">
+          <SectionEyebrow>Cómo funciona Boreas</SectionEyebrow>
           <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.8vw,4.25rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
-            Boreas organiza revenue como sistema.
+            Boreas está pensado para acompañar
             <br className="hidden sm:block" />
-            Relevo es la capa activa hoy.
+            todo el camino del cliente.
           </h2>
-          <p className="mx-auto mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg">
-            No vendemos piezas sueltas. Boreas ordena adquisición, conversión y retención como un
-            sistema operativo. En v2.1 el foco absoluto está en conversión, porque esa es la capa
-            que hoy genera resultados medibles más rápido.
+          <p className="mt-6 max-w-3xl text-base leading-7 text-white/56 sm:text-lg lg:mx-0">
+            Hoy Relevo es la parte que ya está lista para responder, guiar y ayudar a cerrar más
+            conversaciones. Después, Boreas seguirá creciendo hacia el resto del recorrido.
           </p>
         </div>
 

--- a/components/landing/problem-section.tsx
+++ b/components/landing/problem-section.tsx
@@ -36,7 +36,7 @@ export function ProblemSection() {
         className="pointer-events-none absolute left-[20%] top-20 h-96 w-96 -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(216,204,178,0.08),transparent_70%)] blur-[110px]"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
         <div className="grid items-center gap-16 lg:grid-cols-[1.1fr_0.9fr] lg:gap-20">
           <div data-reveal className="max-w-2xl px-2">
             <SectionEyebrow>El Problema</SectionEyebrow>

--- a/components/landing/trust-proof-section.tsx
+++ b/components/landing/trust-proof-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { metricCards } from "@/content/boreas-home";
+
 import { SectionEyebrow, SectionFrame } from "./boreas-landing-sections";
 
 export function TrustAndProofSection() {
@@ -18,52 +20,54 @@ export function TrustAndProofSection() {
             className="flex flex-col justify-center rounded-[2.5rem] border border-white/8 bg-white/[0.02] px-8 py-12 shadow-[0_24px_80px_rgba(0,0,0,0.16)] backdrop-blur-sm"
           >
             <p className="text-[0.68rem] uppercase tracking-[0.34em] text-[#d8ccb2]/60">
-              Impacto en Métricas
+              Métricas v2.1
             </p>
-            <p className="mt-6 text-[clamp(4.8rem,10vw,7.5rem)] font-medium leading-none tracking-[-0.08em] text-[#d8ccb2]">
-              3x
+            <p className="mt-6 text-[clamp(3.8rem,8vw,6.5rem)] font-medium leading-none tracking-[-0.08em] text-[#d8ccb2]">
+              4
             </p>
-            <p className="mt-4 max-w-[14rem] text-sm leading-relaxed text-white/50">
-              Aumento comprobado en conversión cuando respondes a una solicitud en menos de 2 minutos.
+            <p className="mt-4 max-w-[18rem] text-sm leading-relaxed text-white/50">
+              Señales principales para evaluar si Relevo está empujando revenue de forma real, no
+              solo generando conversación.
             </p>
-            
+
             <div className="my-8 h-px bg-gradient-to-r from-[#d8ccb2]/20 to-transparent" />
-            
-            <p className="text-[clamp(3.2rem,6vw,4.5rem)] font-medium leading-none tracking-[-0.06em] text-white/90">
-              100%
-            </p>
-             <p className="mt-4 max-w-[15rem] text-sm leading-relaxed text-white/50">
-              Cobertura continua sin brechas operativas. Noches, domingos y días festivos.
-            </p>
 
-            <div className="my-8 h-px bg-gradient-to-r from-white/10 to-transparent" />
-
-            <p className="text-[clamp(3.2rem,6vw,4.5rem)] font-medium leading-none tracking-[-0.06em] text-white/90">
-              &lt; 5s
+            <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">
+              Qué cambia en v2.1
             </p>
-             <p className="mt-4 max-w-[15rem] text-sm leading-relaxed text-white/50">
-              Latencia promedio de respuesta. Atención inmediata e ininterrumpida.
+            <p className="mt-4 text-base leading-7 text-white/58">
+              En lugar de prometer números absolutos desde la landing, Boreas estructura la
+              operación para medir velocidad, avance y acciones cerradas desde el primer despliegue.
             </p>
           </div>
 
           <div data-reveal className="max-w-4xl py-6 lg:py-12">
-            <SectionEyebrow>El valor estratégico</SectionEyebrow>
+            <SectionEyebrow>Medición útil</SectionEyebrow>
             <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.7vw,4.2rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
-              El cliente moderno no espera. Tu negocio tampoco debería.
+              Control antes que flexibilidad.
+              <br className="hidden sm:block" />
+              Datos antes que narrativa.
             </h2>
             <p className="mt-8 max-w-2xl text-lg leading-relaxed text-white/60">
-              Muchas empresas y profesionales subestiman la <i>&quot;fuga invisible&quot;</i>: ese prospecto que envió un mensaje a las 9 PM interesándose por un servicio, no recibió respuesta, y a la mañana siguiente ya cerró trato con la competencia directa que sí le atendió de inmediato.
+              Boreas no parte de una promesa difusa de IA. Parte de indicadores operativos que sí
+              pueden compararse con la realidad del negocio: cuánto tardas en entrar, cuánto logra
+              avanzar la conversación y cuántas acciones concretas se cierran.
             </p>
-            
-            <div className="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-4">
-               <div className="rounded-[1.5rem] border border-[rgba(255,255,255,0.06)] bg-white/[0.015] p-6 transition-colors hover:bg-white/[0.03]">
-                  <h4 className="text-sm uppercase tracking-[0.2em] text-[#d8ccb2]/60">Volumen Masivo</h4>
-                  <p className="mt-3 text-[15px] leading-relaxed text-white/70">Atiende flujos agresivos de tráfico publicitario sin saturar el ancho de banda mental de tus recepcionistas.</p>
-               </div>
-               <div className="rounded-[1.5rem] border border-[rgba(255,255,255,0.06)] bg-white/[0.015] p-6 transition-colors hover:bg-white/[0.03]">
-                  <h4 className="text-sm uppercase tracking-[0.2em] text-[#d8ccb2]/60">Decisión Lógica</h4>
-                  <p className="mt-3 text-[15px] leading-relaxed text-white/70">Maneja a los clientes difíciles basándose puramente en instrucciones lógicas, sin sesgos emocionales ni frustraciones.</p>
-               </div>
+
+            <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {metricCards.map((card) => (
+                <div
+                  key={card.label}
+                  className="rounded-[1.5rem] border border-[rgba(255,255,255,0.06)] bg-white/[0.015] p-6 transition-colors hover:bg-white/[0.03]"
+                >
+                  <h4 className="text-sm uppercase tracking-[0.2em] text-[#d8ccb2]/60">
+                    {card.label}
+                  </h4>
+                  <p className="mt-3 text-[15px] leading-relaxed text-white/70">
+                    {card.description}
+                  </p>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/components/landing/trust-proof-section.tsx
+++ b/components/landing/trust-proof-section.tsx
@@ -13,45 +13,44 @@ export function TrustAndProofSection() {
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
       />
 
-      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-10">
+      <div className="relative mx-auto max-w-[1460px] px-4 sm:px-6 lg:px-10">
         <div className="grid items-start gap-10 lg:grid-cols-[0.75fr_1.25fr] lg:gap-16">
           <div
             data-reveal
             className="flex flex-col justify-center rounded-[2.5rem] border border-white/8 bg-white/[0.02] px-8 py-12 shadow-[0_24px_80px_rgba(0,0,0,0.16)] backdrop-blur-sm"
           >
             <p className="text-[0.68rem] uppercase tracking-[0.34em] text-[#d8ccb2]/60">
-              Métricas v2.1
+              Métricas clave
             </p>
             <p className="mt-6 text-[clamp(3.8rem,8vw,6.5rem)] font-medium leading-none tracking-[-0.08em] text-[#d8ccb2]">
               4
             </p>
             <p className="mt-4 max-w-[18rem] text-sm leading-relaxed text-white/50">
-              Señales principales para evaluar si Relevo está empujando revenue de forma real, no
-              solo generando conversación.
+              Señales principales para ver si Relevo está ayudando de verdad, no solo generando
+              respuestas bonitas.
             </p>
 
             <div className="my-8 h-px bg-gradient-to-r from-[#d8ccb2]/20 to-transparent" />
 
             <p className="text-[0.68rem] uppercase tracking-[0.3em] text-white/32">
-              Qué cambia en v2.1
+              Qué vamos a mirar
             </p>
             <p className="mt-4 text-base leading-7 text-white/58">
-              En lugar de prometer números absolutos desde la landing, Boreas estructura la
-              operación para medir velocidad, avance y acciones cerradas desde el primer despliegue.
+              En vez de prometer resultados inflados desde la página, Boreas te ayuda a medir
+              rapidez, avance y acciones cerradas desde el inicio.
             </p>
           </div>
 
           <div data-reveal className="max-w-4xl py-6 lg:py-12">
             <SectionEyebrow>Medición útil</SectionEyebrow>
             <h2 className="mt-6 text-balance text-[clamp(2.2rem,4.7vw,4.2rem)] font-medium leading-[1.06] tracking-[-0.055em] text-[#f7f1ea]">
-              Control antes que flexibilidad.
+              Primero claridad.
               <br className="hidden sm:block" />
-              Datos antes que narrativa.
+              Luego resultados.
             </h2>
             <p className="mt-8 max-w-2xl text-lg leading-relaxed text-white/60">
-              Boreas no parte de una promesa difusa de IA. Parte de indicadores operativos que sí
-              pueden compararse con la realidad del negocio: cuánto tardas en entrar, cuánto logra
-              avanzar la conversación y cuántas acciones concretas se cierran.
+              Boreas no se queda en una promesa abstracta. Se nota en tiempos de respuesta,
+              conversaciones que sí avanzan y acciones concretas que el negocio puede ver.
             </p>
 
             <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -1,0 +1,97 @@
+const navLinks = [
+  { label: "Cómo funciona", href: "#como-funciona" },
+  { label: "Demo", href: "#demo-relevo" },
+  { label: "Sectores", href: "#sectores" },
+  { label: "Diagnóstico", href: "#diagnostico" },
+];
+
+const productLinks = [
+  { label: "Abrir Relevo", href: "https://relevo.chat" },
+  { label: "Ver demo", href: "#demo-relevo" },
+];
+
+export function SiteFooter() {
+  return (
+    <footer className="relative overflow-hidden border-t border-white/8 bg-[#0b0e11] text-[#f5f1ea]">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-0 h-72 w-[56rem] -translate-x-1/2 bg-[radial-gradient(circle,rgba(216,204,178,0.1),transparent_72%)] blur-[130px]"
+      />
+
+      <div className="relative mx-auto max-w-[1460px] px-4 py-14 sm:px-6 lg:px-10">
+        <div className="grid gap-12 lg:grid-cols-[1.25fr_0.6fr_0.7fr] lg:gap-16">
+          <div className="max-w-xl">
+            <p className="text-[0.72rem] uppercase tracking-[0.38em] text-white/30">Boreas</p>
+            <h2 className="mt-5 text-balance text-[clamp(1.9rem,3vw,3rem)] font-medium leading-[1.05] tracking-[-0.05em] text-[#f7f1ea]">
+              Responde más rápido y convierte más conversaciones en citas.
+            </h2>
+            <p className="mt-5 max-w-2xl text-base leading-7 text-white/58">
+              Hoy Relevo te ayuda a contestar al momento y llevar a cada persona al siguiente paso
+              con una atención más clara, rápida y constante.
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              <a
+                href="#diagnostico"
+                className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/[0.04] px-5 py-3 text-sm font-medium text-[#f7f1ea] transition-all duration-300 hover:border-white/24 hover:bg-white/[0.08]"
+              >
+                Ver diagnóstico
+              </a>
+              <a
+                href="https://relevo.chat"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-[#d4c0a1]/22 bg-[linear-gradient(180deg,rgba(216,204,178,0.18)_0%,rgba(216,204,178,0.1)_100%)] px-5 py-3 text-sm font-medium text-[#fbfcfd] transition-all duration-300 hover:border-[#d4c0a1]/35 hover:brightness-110"
+              >
+                Abrir Relevo
+              </a>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.28em] text-[#d8ccb2]/70">
+              Navegación
+            </p>
+            <div className="mt-5 flex flex-col gap-3 text-sm text-white/64">
+              {navLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  className="transition-colors duration-300 hover:text-white"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.28em] text-[#d8ccb2]/70">
+              Producto
+            </p>
+            <div className="mt-5 flex flex-col gap-3 text-sm text-white/64">
+              {productLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target={link.href.startsWith("http") ? "_blank" : undefined}
+                  rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                  className="transition-colors duration-300 hover:text-white"
+                >
+                  {link.label}
+                </a>
+              ))}
+              <p className="pt-3 text-sm leading-6 text-white/46">
+                Sectores activos: salud, belleza e inmobiliario.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-14 border-t border-white/8 pt-6 text-sm text-white/38">
+          Boreas · Relevo listo para responder, guiar y ayudar a cerrar mejor
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/content/boreas-home.ts
+++ b/content/boreas-home.ts
@@ -2,97 +2,97 @@ export const heroWords = ["salud", "belleza", "inmobiliario"];
 
 export const platformLayers = [
   {
-    title: "Adquisición",
-    status: "Futuro",
+    title: "Atraer",
+    status: "Más adelante",
     description:
-      "Boreas ordenará la generación de tráfico e intención cuando la capa de conversión ya esté dominada.",
+      "Más adelante Boreas también ayudará a atraer más interés y más conversaciones nuevas.",
   },
   {
-    title: "Conversión",
-    status: "Activo ahora",
+    title: "Atender y convertir",
+    status: "Disponible hoy",
     description:
-      "Relevo responde, califica y empuja leads a acciones concretas con playbooks diseñados por industria.",
+      "Hoy Relevo responde, entiende lo que busca cada persona y la lleva al siguiente paso.",
   },
   {
-    title: "Retención",
-    status: "Siguiente fase",
+    title: "Volver a activar",
+    status: "Próximo paso",
     description:
-      "Seguimiento, reactivación y fidelización se activarán sobre una base ya medida de revenue y conversiones.",
+      "Después llegarán recordatorios, seguimiento y formas de hacer que más clientes regresen.",
   },
 ];
 
 export const playbookPhases = [
   {
     number: "01",
-    title: "Apertura",
+    title: "Primer mensaje",
     description:
-      "Relevo toma la intención entrante sin sonar a bot y abre la conversación con el tono correcto.",
+      "Relevo responde rápido y con el tono correcto desde el primer momento.",
   },
   {
     number: "02",
-    title: "Calificación mínima",
+    title: "Entender qué necesita",
     description:
-      "Obtiene la información indispensable para separar curiosidad, urgencia y lead realmente accionable.",
+      "Hace las preguntas justas para saber si la persona quiere una cita, una visita o más información.",
   },
   {
     number: "03",
-    title: "Micro venta",
+    title: "Resolver dudas",
     description:
-      "Aclara valor, reduce fricción y orienta la conversación hacia una decisión concreta.",
+      "Aclara lo importante y ayuda a que la conversación no se enfríe.",
   },
   {
     number: "04",
-    title: "Push a acción",
+    title: "Llevarlo al siguiente paso",
     description:
-      "Conduce al lead hacia agenda, visita, consulta o siguiente paso sin dejar la conversación abierta.",
+      "Propone una cita, visita, llamada o siguiente paso sin dejar la conversación abierta.",
   },
   {
     number: "05",
-    title: "Objeciones y cierre",
+    title: "Cerrar bien",
     description:
-      "Maneja dudas comunes, refuerza contexto y cierra con una acción medible para el negocio.",
+      "Responde objeciones comunes y busca cerrar con una acción clara para el negocio.",
   },
 ];
 
 export const playbookCards = [
   {
-    title: "Playbook por industria",
+    title: "Guía por industria",
     description:
-      "La lógica de conversación no se improvisa. Cada vertical activa una estructura distinta de preguntas, filtros y cierres.",
+      "Cada sector necesita una manera distinta de responder, orientar y cerrar.",
     accent: "main",
   },
   {
-    title: "Contexto del negocio",
+    title: "Datos de tu negocio",
     description:
-      "Relevo usa horarios, precios, ubicación, servicios y reglas comerciales para responder con precisión operativa.",
+      "Relevo usa horarios, precios, ubicación y servicios para responder con contexto real.",
     accent: "neutral",
   },
   {
-    title: "Estilo y tono",
+    title: "Tu forma de hablar",
     description:
-      "La personalización sucede sobre el estilo, no sobre la lógica de conversión. Eso mantiene consistencia y control.",
+      "El tono se adapta a tu marca sin perder claridad ni consistencia.",
     accent: "neutral",
   },
   {
-    title: "Resultados medibles",
+    title: "Resultados claros",
     description:
-      "Cada playbook está diseñado para mejorar tiempos de respuesta, avance conversacional y citas agendadas.",
+      "Todo se piensa para responder antes, avanzar mejor y lograr más citas o visitas.",
     accent: "accent",
   },
 ];
 
 export const comparisonFlows = {
   manual: [
-    "El lead pregunta y entra en espera.",
-    "La respuesta depende del tiempo y del ancho de banda humano.",
+    "La persona escribe y queda esperando.",
+    "La respuesta depende de si alguien alcanza a contestar.",
     "La conversación se enfría o se va con la competencia.",
-    "El negocio pierde revenue sin verlo claramente.",
+    "El negocio pierde oportunidades sin notarlo a tiempo.",
   ],
   relevo: [
-    "La intención se captura al instante.",
-    "Relevo califica, ordena contexto y reduce fricción.",
-    "El playbook empuja a una acción concreta.",
-    "La conversación termina en un resultado medible.",
+    "La conversación recibe atención al momento.",
+    "Relevo entiende mejor qué busca esa persona.",
+    "La guía correcta la lleva a una cita, visita o llamada.",
+    "La conversación termina con un siguiente paso claro.",
   ],
 };
 
@@ -101,46 +101,46 @@ export const verticals = [
     vertical: "Salud",
     pain: "Consultas perdidas, pacientes sin respuesta y recepción saturada.",
     lead: "Pacientes que preguntan por disponibilidad, valoración o siguiente paso.",
-    action: "Consulta, triage comercial o cita agendada.",
+    action: "Consulta, orientación inicial o cita agendada.",
   },
   {
     vertical: "Belleza",
     pain: "Reservas que se enfrían por demora, cambios de horario y seguimiento irregular.",
     lead: "Clientes que buscan servicio, precio, agenda o recomendación.",
-    action: "Reserva confirmada o conversación reencaminada a agenda.",
+    action: "Reserva confirmada o siguiente paso claro.",
   },
   {
     vertical: "Inmobiliario",
-    pain: "Leads sin priorización, visitas mal filtradas y agentes reaccionando tarde.",
+    pain: "Mensajes sin prioridad, visitas mal filtradas y respuestas tardías.",
     lead: "Prospectos que preguntan por propiedad, presupuesto, zona o visita.",
-    action: "Visita, llamada de calificación o siguiente acción comercial.",
+    action: "Visita, llamada para entender el caso o siguiente paso claro.",
   },
 ];
 
 export const onboardingSteps = [
   {
     number: "01",
-    title: "Eliges industria",
+    title: "Nos dices a qué te dedicas",
     description:
-      "Salud, belleza o inmobiliario para activar el marco correcto de conversación y prioridad comercial.",
+      "Salud, belleza o inmobiliario para arrancar con el enfoque correcto.",
   },
   {
     number: "02",
-    title: "Compartes contexto",
+    title: "Nos compartes lo básico",
     description:
-      "Servicios, horarios, ubicación, precios y reglas operativas. Tú no diseñas la lógica; solo aportas datos del negocio.",
+      "Servicios, horarios, ubicación y precios. Tú pones la información; Boreas pone la estructura.",
   },
   {
     number: "03",
-    title: "Activamos el playbook",
+    title: "Lo dejamos listo",
     description:
-      "Relevo ajusta tono, contexto y objetivos sobre una estructura de conversión ya definida.",
+      "Relevo adapta el tono y la ruta de atención para tu negocio.",
   },
   {
     number: "04",
-    title: "Empiezas a medir",
+    title: "Empezamos a medir",
     description:
-      "El sistema se evalúa por tiempos de respuesta, avance de conversación y acciones cerradas.",
+      "Desde el inicio vemos qué tan rápido responde y cuántas conversaciones terminan en una acción real.",
   },
 ];
 
@@ -148,22 +148,22 @@ export const metricCards = [
   {
     label: "Tiempo de respuesta",
     description:
-      "Qué tan rápido entra el sistema a la conversación cuando aparece intención real.",
+      "Qué tan rápido se atiende una conversación cuando alguien de verdad quiere avanzar.",
   },
   {
-    label: "Tasa de respuesta",
+    label: "Conversaciones atendidas",
     description:
-      "Cuántos leads reciben atención efectiva antes de enfriarse o desaparecer.",
+      "Cuántas personas reciben respuesta antes de enfriarse o irse.",
   },
   {
-    label: "Tasa de avance",
+    label: "Conversaciones que avanzan",
     description:
-      "Cuántas conversaciones superan la etapa superficial y se mueven hacia una decisión.",
+      "Cuántas conversaciones pasan de una duda inicial a un siguiente paso.",
   },
   {
-    label: "Citas agendadas",
+    label: "Citas o visitas logradas",
     description:
-      "Cuántas interacciones terminan en una acción concreta y medible para el negocio.",
+      "Cuántas conversaciones terminan en una cita, visita o llamada concreta.",
   },
 ];
 
@@ -171,31 +171,31 @@ export const faqs = [
   {
     question: "¿Qué diferencia hay entre Boreas y Relevo?",
     answer:
-      "Boreas es la plataforma operativa de revenue. Relevo es el primer módulo activo dentro de ese sistema y se encarga específicamente de la conversión: responder, calificar y empujar leads a una acción concreta.",
+      "Boreas es la marca y la base completa. Relevo es lo que hoy ya puedes ver funcionando: responde, orienta y ayuda a cerrar más conversaciones.",
   },
   {
     question: "¿Por qué trabajan tres verticales al mismo tiempo?",
     answer:
-      "Porque Boreas no se adapta con un discurso genérico, sino con playbooks por industria. La estructura comercial es compartida, pero cada vertical activa preguntas, filtros y cierres distintos.",
+      "Porque salud, belleza e inmobiliario comparten el problema de responder tarde, pero cada uno necesita una forma distinta de orientar la conversación.",
   },
   {
     question: "¿El negocio tiene que diseñar la conversación?",
     answer:
-      "No. El negocio solo comparte información operativa como horarios, precios, ubicación y servicios. La lógica de conversión ya vive dentro del playbook que activa Relevo.",
+      "No. Solo compartes la información básica del negocio. Boreas se encarga de la forma en que Relevo atiende y guía la conversación.",
   },
   {
-    question: "¿Esto es un bot con prompts y respuestas sueltas?",
+    question: "¿Es un chatbot genérico?",
     answer:
-      "No. Relevo opera con una arquitectura de playbook, contexto y estilo. El prompt es solo una capa; la conversión depende de la estructura completa del sistema.",
+      "No. Relevo no responde al azar. Sigue una guía clara para entender, responder y ayudar a cerrar cada conversación.",
   },
   {
     question: "¿Qué se mide para saber si está funcionando?",
     answer:
-      "Tiempo de respuesta, tasa de respuesta, tasa de avance en conversación y acciones cerradas como citas agendadas, visitas o llamadas calificadas.",
+      "Cuánto tardas en responder, cuántas conversaciones sí reciben atención, cuántas avanzan y cuántas terminan en una cita, visita o llamada.",
   },
   {
-    question: "¿El CTA final ya está cerrado en v2.1?",
+    question: "¿Puedo ver si esto me serviría sin dejar mis datos?",
     answer:
-      "No del todo. En esta versión Boreas elimina la dependencia de mailto y prueba un flujo de diagnóstico de bajo roce para aprender qué formato convierte mejor sin aumentar fricción innecesaria.",
+      "Sí. El diagnóstico rápido te orienta con cuatro preguntas y no te pide correo ni conexión técnica para darte una primera recomendación.",
   },
 ];

--- a/content/boreas-home.ts
+++ b/content/boreas-home.ts
@@ -1,0 +1,201 @@
+export const heroWords = ["salud", "belleza", "inmobiliario"];
+
+export const platformLayers = [
+  {
+    title: "Adquisición",
+    status: "Futuro",
+    description:
+      "Boreas ordenará la generación de tráfico e intención cuando la capa de conversión ya esté dominada.",
+  },
+  {
+    title: "Conversión",
+    status: "Activo ahora",
+    description:
+      "Relevo responde, califica y empuja leads a acciones concretas con playbooks diseñados por industria.",
+  },
+  {
+    title: "Retención",
+    status: "Siguiente fase",
+    description:
+      "Seguimiento, reactivación y fidelización se activarán sobre una base ya medida de revenue y conversiones.",
+  },
+];
+
+export const playbookPhases = [
+  {
+    number: "01",
+    title: "Apertura",
+    description:
+      "Relevo toma la intención entrante sin sonar a bot y abre la conversación con el tono correcto.",
+  },
+  {
+    number: "02",
+    title: "Calificación mínima",
+    description:
+      "Obtiene la información indispensable para separar curiosidad, urgencia y lead realmente accionable.",
+  },
+  {
+    number: "03",
+    title: "Micro venta",
+    description:
+      "Aclara valor, reduce fricción y orienta la conversación hacia una decisión concreta.",
+  },
+  {
+    number: "04",
+    title: "Push a acción",
+    description:
+      "Conduce al lead hacia agenda, visita, consulta o siguiente paso sin dejar la conversación abierta.",
+  },
+  {
+    number: "05",
+    title: "Objeciones y cierre",
+    description:
+      "Maneja dudas comunes, refuerza contexto y cierra con una acción medible para el negocio.",
+  },
+];
+
+export const playbookCards = [
+  {
+    title: "Playbook por industria",
+    description:
+      "La lógica de conversación no se improvisa. Cada vertical activa una estructura distinta de preguntas, filtros y cierres.",
+    accent: "main",
+  },
+  {
+    title: "Contexto del negocio",
+    description:
+      "Relevo usa horarios, precios, ubicación, servicios y reglas comerciales para responder con precisión operativa.",
+    accent: "neutral",
+  },
+  {
+    title: "Estilo y tono",
+    description:
+      "La personalización sucede sobre el estilo, no sobre la lógica de conversión. Eso mantiene consistencia y control.",
+    accent: "neutral",
+  },
+  {
+    title: "Resultados medibles",
+    description:
+      "Cada playbook está diseñado para mejorar tiempos de respuesta, avance conversacional y citas agendadas.",
+    accent: "accent",
+  },
+];
+
+export const comparisonFlows = {
+  manual: [
+    "El lead pregunta y entra en espera.",
+    "La respuesta depende del tiempo y del ancho de banda humano.",
+    "La conversación se enfría o se va con la competencia.",
+    "El negocio pierde revenue sin verlo claramente.",
+  ],
+  relevo: [
+    "La intención se captura al instante.",
+    "Relevo califica, ordena contexto y reduce fricción.",
+    "El playbook empuja a una acción concreta.",
+    "La conversación termina en un resultado medible.",
+  ],
+};
+
+export const verticals = [
+  {
+    vertical: "Salud",
+    pain: "Consultas perdidas, pacientes sin respuesta y recepción saturada.",
+    lead: "Pacientes que preguntan por disponibilidad, valoración o siguiente paso.",
+    action: "Consulta, triage comercial o cita agendada.",
+  },
+  {
+    vertical: "Belleza",
+    pain: "Reservas que se enfrían por demora, cambios de horario y seguimiento irregular.",
+    lead: "Clientes que buscan servicio, precio, agenda o recomendación.",
+    action: "Reserva confirmada o conversación reencaminada a agenda.",
+  },
+  {
+    vertical: "Inmobiliario",
+    pain: "Leads sin priorización, visitas mal filtradas y agentes reaccionando tarde.",
+    lead: "Prospectos que preguntan por propiedad, presupuesto, zona o visita.",
+    action: "Visita, llamada de calificación o siguiente acción comercial.",
+  },
+];
+
+export const onboardingSteps = [
+  {
+    number: "01",
+    title: "Eliges industria",
+    description:
+      "Salud, belleza o inmobiliario para activar el marco correcto de conversación y prioridad comercial.",
+  },
+  {
+    number: "02",
+    title: "Compartes contexto",
+    description:
+      "Servicios, horarios, ubicación, precios y reglas operativas. Tú no diseñas la lógica; solo aportas datos del negocio.",
+  },
+  {
+    number: "03",
+    title: "Activamos el playbook",
+    description:
+      "Relevo ajusta tono, contexto y objetivos sobre una estructura de conversión ya definida.",
+  },
+  {
+    number: "04",
+    title: "Empiezas a medir",
+    description:
+      "El sistema se evalúa por tiempos de respuesta, avance de conversación y acciones cerradas.",
+  },
+];
+
+export const metricCards = [
+  {
+    label: "Tiempo de respuesta",
+    description:
+      "Qué tan rápido entra el sistema a la conversación cuando aparece intención real.",
+  },
+  {
+    label: "Tasa de respuesta",
+    description:
+      "Cuántos leads reciben atención efectiva antes de enfriarse o desaparecer.",
+  },
+  {
+    label: "Tasa de avance",
+    description:
+      "Cuántas conversaciones superan la etapa superficial y se mueven hacia una decisión.",
+  },
+  {
+    label: "Citas agendadas",
+    description:
+      "Cuántas interacciones terminan en una acción concreta y medible para el negocio.",
+  },
+];
+
+export const faqs = [
+  {
+    question: "¿Qué diferencia hay entre Boreas y Relevo?",
+    answer:
+      "Boreas es la plataforma operativa de revenue. Relevo es el primer módulo activo dentro de ese sistema y se encarga específicamente de la conversión: responder, calificar y empujar leads a una acción concreta.",
+  },
+  {
+    question: "¿Por qué trabajan tres verticales al mismo tiempo?",
+    answer:
+      "Porque Boreas no se adapta con un discurso genérico, sino con playbooks por industria. La estructura comercial es compartida, pero cada vertical activa preguntas, filtros y cierres distintos.",
+  },
+  {
+    question: "¿El negocio tiene que diseñar la conversación?",
+    answer:
+      "No. El negocio solo comparte información operativa como horarios, precios, ubicación y servicios. La lógica de conversión ya vive dentro del playbook que activa Relevo.",
+  },
+  {
+    question: "¿Esto es un bot con prompts y respuestas sueltas?",
+    answer:
+      "No. Relevo opera con una arquitectura de playbook, contexto y estilo. El prompt es solo una capa; la conversión depende de la estructura completa del sistema.",
+  },
+  {
+    question: "¿Qué se mide para saber si está funcionando?",
+    answer:
+      "Tiempo de respuesta, tasa de respuesta, tasa de avance en conversación y acciones cerradas como citas agendadas, visitas o llamadas calificadas.",
+  },
+  {
+    question: "¿El CTA final ya está cerrado en v2.1?",
+    answer:
+      "No del todo. En esta versión Boreas elimina la dependencia de mailto y prueba un flujo de diagnóstico de bajo roce para aprender qué formato convierte mejor sin aumentar fricción innecesaria.",
+  },
+];

--- a/docs/product/boreas-v2.1-epics-subtasks.md
+++ b/docs/product/boreas-v2.1-epics-subtasks.md
@@ -1,0 +1,154 @@
+# Boreas v2.1 - EPICs y Subtasks
+
+## Overview
+
+Este backlog traduce el PRD `v2.1` a unidades ejecutables. Cada `EPIC v2.1` representa un bloque mayor de entrega. Cada `Subtask v2.1` representa trabajo accionable y verificable.
+
+## EPIC v2.1.1 - Reposicionamiento de marca y arquitectura narrativa
+
+### Objetivo
+
+Separar con claridad la arquitectura de marca:
+
+- Boreas = plataforma operativa de revenue
+- Relevo = modulo actual de conversion
+
+### Resultado esperado
+
+Un usuario nuevo entiende inmediatamente la diferencia entre la marca paraguas y el modulo comercial activo.
+
+### Subtasks
+
+- `Subtask v2.1.1.1` Reescribir metadata global, title y description para reflejar la nueva arquitectura Boreas/Relevo.
+- `Subtask v2.1.1.2` Rediseñar el hero para vender Boreas como sistema y Relevo como el primer motor operativo.
+- `Subtask v2.1.1.3` Reescribir el headline y supporting copy eliminando ambiguedades de "IA a tu favor" y enfocandolo en revenue y conversion.
+- `Subtask v2.1.1.4` Renombrar referencias visuales y textuales donde hoy Boreas aparece como si fuera directamente el agente conversacional.
+- `Subtask v2.1.1.5` Ajustar la estructura del homepage para que la narrativa siga esta secuencia: problema, sistema Boreas, modulo Relevo, prueba, verticales, onboarding, CTA.
+
+## EPIC v2.1.2 - Estrategia multi-vertical con compensacion de claridad
+
+### Objetivo
+
+Sostener tres verticales prioritarias en paralelo sin caer en una propuesta generica.
+
+### Resultado esperado
+
+Salud, belleza e inmobiliario aparecen como casos fuertes dentro de un sistema coherente, no como una lista dispersa de industrias.
+
+### Subtasks
+
+- `Subtask v2.1.2.1` Replantear la seccion de verticales para reflejar salud, belleza e inmobiliario como focos principales de `v2.1`.
+- `Subtask v2.1.2.2` Crear micro-copy diferencial por vertical basado en problema, tipo de lead y accion objetivo.
+- `Subtask v2.1.2.3` Diseñar una seccion de contenido que explique por que Boreas/Relevo pueden operar en tres verticales sin perder estructura.
+- `Subtask v2.1.2.4` Mostrar que la adaptacion por industria ocurre via playbooks, no por personalizacion superficial.
+- `Subtask v2.1.2.5` Revisar claims y ejemplos actuales para eliminar referencias que sobrerrepresenten una sola industria o abran demasiadas categorias no prioritarias.
+
+## EPIC v2.1.3 - Sistema de playbooks como ventaja competitiva
+
+### Objetivo
+
+Convertir la explicacion de playbooks en el mecanismo central que aumenta confianza y compensa la dilution del enfoque multi-vertical.
+
+### Resultado esperado
+
+El usuario entiende que Relevo no depende de prompts improvisados, sino de una estructura operacional por industria.
+
+### Subtasks
+
+- `Subtask v2.1.3.1` Crear una seccion explicita que defina que es un playbook dentro de Relevo.
+- `Subtask v2.1.3.2` Visualizar la anatomia del playbook: apertura, calificacion, microventa, push a accion, objeciones y cierre.
+- `Subtask v2.1.3.3` Explicar la arquitectura interna: playbook, contexto del negocio y estilo.
+- `Subtask v2.1.3.4` Reescribir beneficios actuales para conectarlos con logica de conversion y no con automatizacion generica.
+- `Subtask v2.1.3.5` Integrar ejemplos por vertical que demuestren especializacion real sin saturar el homepage.
+
+## EPIC v2.1.4 - CTA principal y nuevo flujo de conversion
+
+### Objetivo
+
+Reemplazar `mailto:` por un sistema de accion real y medible, dejando abierta la solucion exacta hasta la exploracion de alternativas.
+
+### Resultado esperado
+
+La web deja de depender del correo manual y pasa a un flujo de captura o agenda optimizado para conversion.
+
+### Subtasks
+
+- `Subtask v2.1.4.1` Inventariar alternativas a `mailto:` para el CTA principal.
+- `Subtask v2.1.4.2` Definir criterios de decision para elegir CTA: friccion, calidad del lead, velocidad, trazabilidad y percepcion de valor.
+- `Subtask v2.1.4.3` Diseñar la experiencia base del nuevo CTA sin comprometer aun la solucion final.
+- `Subtask v2.1.4.4` Si se elige formulario, diseñar una version de alta conversion con entrega clara de valor al usuario.
+- `Subtask v2.1.4.5` Reemplazar todos los `mailto:` del sitio por el nuevo entrypoint acordado.
+- `Subtask v2.1.4.6` Instrumentar eventos para medir inicio, abandono y finalizacion del flujo.
+
+## EPIC v2.1.5 - Demo de Relevo y prueba de mecanismo
+
+### Objetivo
+
+Hacer que la demo y las secciones visuales representen correctamente a Relevo como motor de conversion.
+
+### Resultado esperado
+
+La experiencia visual demuestra calificacion, avance y cierre, no solo una conversacion agradable.
+
+### Subtasks
+
+- `Subtask v2.1.5.1` Renombrar la demo para que la entidad visible sea Relevo cuando corresponde.
+- `Subtask v2.1.5.2` Ajustar el flujo demo para enfatizar calificacion de lead y push a accion.
+- `Subtask v2.1.5.3` Reescribir estados, labels y activity logs para alinearlos con la tesis de conversion.
+- `Subtask v2.1.5.4` Revisar la seccion de mecanismo para conectar cada paso con una consecuencia comercial real.
+- `Subtask v2.1.5.5` Mejorar la comparativa actual para mostrar perdida de revenue vs conversion estructurada.
+
+## EPIC v2.1.6 - Onboarding como motor de confianza
+
+### Objetivo
+
+Usar onboarding no solo como explicacion operativa, sino como palanca de confianza y conversion.
+
+### Resultado esperado
+
+El usuario percibe implementacion simple, controlada y orientada a resultados.
+
+### Subtasks
+
+- `Subtask v2.1.6.1` Crear una seccion dedicada al onboarding dentro del homepage o flujo complementario.
+- `Subtask v2.1.6.2` Explicar que el cliente no diseña la logica, solo aporta datos del negocio.
+- `Subtask v2.1.6.3` Mostrar de forma simple los inputs requeridos: industria, horarios, precios, ubicacion y contexto operativo.
+- `Subtask v2.1.6.4` Reforzar la idea de control sobre flexibilidad para reducir objeciones.
+- `Subtask v2.1.6.5` Integrar onboarding con el discurso de playbooks para elevar confianza.
+
+## EPIC v2.1.7 - Medicion, SEO y capa de contenido
+
+### Objetivo
+
+Preparar la version `2.1` para iteracion real con datos, manteniendo contenido facil de actualizar.
+
+### Resultado esperado
+
+El sitio puede medirse, el mensaje puede evolucionar rapido y la base tecnica soporta iteracion comercial.
+
+### Subtasks
+
+- `Subtask v2.1.7.1` Implementar una capa centralizada para contenido estrategico y copy principal.
+- `Subtask v2.1.7.2` Actualizar SEO on-page y metadata segun el nuevo posicionamiento.
+- `Subtask v2.1.7.3` Definir taxonomy de eventos de conversion y engagement.
+- `Subtask v2.1.7.4` Instrumentar eventos clave de CTA, vertical, demo y scroll.
+- `Subtask v2.1.7.5` Revisar que las secciones estaticas puedan permanecer server-first donde no haga falta comportamiento client-side.
+
+## Orden recomendado de ejecucion
+
+1. `EPIC v2.1.1` Reposicionamiento de marca y arquitectura narrativa
+2. `EPIC v2.1.2` Estrategia multi-vertical con compensacion de claridad
+3. `EPIC v2.1.3` Sistema de playbooks como ventaja competitiva
+4. `EPIC v2.1.4` CTA principal y nuevo flujo de conversion
+5. `EPIC v2.1.5` Demo de Relevo y prueba de mecanismo
+6. `EPIC v2.1.6` Onboarding como motor de confianza
+7. `EPIC v2.1.7` Medicion, SEO y capa de contenido
+
+## Definition of done de v2.1
+
+- Existe PRD versionado para Boreas `v2.1`.
+- Existen EPICs y subtasks versionados para Boreas `v2.1`.
+- La narrativa del sitio separa Boreas y Relevo correctamente.
+- Las tres verticales principales quedan integradas con claridad suficiente.
+- `mailto:` deja de ser la salida principal o, como minimo, queda formalmente reemplazado en el plan de implementacion acordado.
+- Playbooks y onboarding se vuelven piezas visibles de conversion y confianza.

--- a/docs/product/boreas-v2.1-prd.md
+++ b/docs/product/boreas-v2.1-prd.md
@@ -1,0 +1,207 @@
+# Boreas v2.1 PRD
+
+## Contexto
+
+Este PRD redefine la version `2.1` de Boreas a partir de la estrategia consolidada de Boreas/Relevo.
+
+- `Boreas` es la plataforma operativa de revenue.
+- `Relevo` es el primer modulo activo dentro de Boreas y el motor de conversion.
+- El objetivo inmediato no es construir un ecosistema completo visible en el sitio, sino comunicar con claridad la arquitectura del sistema y vender con precision el primer modulo que ya genera valor.
+
+## Decision estrategica de version
+
+La version `2.1` de Boreas se construira sobre estas decisiones:
+
+- Boreas se posiciona como infraestructura de generacion de revenue, no como un hub de herramientas ni una automatizacion aislada.
+- Relevo se posiciona como el modulo de conversion responsable de responder, calificar y llevar leads a acciones concretas, principalmente citas agendadas.
+- El sitio no se enfocara en una sola vertical. La estrategia comercial de `v2.1` trabajara tres verticales principales en paralelo: `salud`, `belleza` e `inmobiliario`.
+- Se acepta conscientemente que esta eleccion puede diluir parte del enfoque. La compensacion vendra por claridad narrativa, contenido mas fuerte y una explicacion mucho mas precisa de los playbooks y del onboarding.
+- El reemplazo de `mailto:` es prioritario, pero la solucion final de CTA no queda cerrada en este PRD. Se evaluaran alternativas de alta conversion antes de elegir una implementacion final.
+- Si se adopta un formulario, debera ser un formulario optimizado para conversion y ofrecer valor claro al usuario a cambio de completarlo.
+
+## Problema actual
+
+El sitio actual comunica Boreas como si fuera directamente el agente que conversa, califica y agenda. Eso mezcla plataforma y modulo en una sola capa mental. Tambien comunica amplitud funcional y promesas operativas por encima del grado de especializacion que hoy conviene vender.
+
+Los principales problemas son:
+
+- No existe una separacion clara entre Boreas y Relevo.
+- La narrativa actual vende automatizacion conversacional, pero no explica la logica estructurada de playbooks por industria.
+- El sitio comunica demasiada amplitud sin anclarla suficientemente en una tesis coherente.
+- Los CTA actuales dependen de `mailto:` y no constituyen un embudo medible.
+- El sitio no convierte su propia promesa en una experiencia de conversion medible dentro de la web.
+
+## Objetivo del producto
+
+Rediseñar el sitio de Boreas para que la version `2.1` logre tres cosas al mismo tiempo:
+
+1. Explicar con claridad la arquitectura `Boreas -> Relevo`.
+2. Vender Relevo como motor de conversion estructurado, medible y escalable.
+3. Soportar tres verticales principales sin que el mensaje se vuelva generico.
+
+## Objetivos de negocio
+
+- Incrementar la claridad de posicionamiento de Boreas y Relevo.
+- Mejorar la calidad de los leads entrantes.
+- Aumentar la tasa de accion sobre el CTA principal.
+- Preparar un sistema web medible para iterar con data real.
+
+## Objetivos de UX y conversion
+
+- Reducir confusion sobre que es Boreas y que es Relevo.
+- Generar confianza en usuarios de salud, belleza e inmobiliario.
+- Mostrar que el sistema no depende de prompts improvisados, sino de playbooks por industria.
+- Reducir friccion en el primer contacto sin sacrificar calidad del lead.
+
+## Audiencias prioritarias
+
+### Primarias
+
+- Negocios de salud que dependen de velocidad de respuesta y agenda.
+- Negocios de belleza y bienestar que viven de reservas y seguimiento comercial.
+- Negocios inmobiliarios donde la velocidad y la calificacion del lead impactan directamente el cierre.
+
+### Secundarias
+
+- Operadores o dueños que quieren resultados economicos, no experimentar con prompts.
+- Equipos pequeños que ya sienten fuga de revenue por tiempos de respuesta lentos.
+
+## Posicionamiento
+
+### Boreas
+
+`Boreas` es una plataforma operativa de revenue que automatiza adquisicion, conversion y retencion con inteligencia artificial.
+
+### Relevo
+
+`Relevo` es el primer modulo de Boreas. Es un motor de conversion que usa playbooks por industria para calificar leads y moverlos hacia acciones concretas como agendar una cita.
+
+## Propuesta de valor
+
+- No se vende "automatizacion de mensajes".
+- No se vende "un bot".
+- No se vende "un stack de IA".
+
+Se vende:
+
+- Menor tiempo de respuesta.
+- Mejor avance conversacional.
+- Mas citas agendadas.
+- Mejor conversion de leads.
+
+## Principios de producto
+
+- Control sobre flexibilidad.
+- Resultados medibles por encima de novedad.
+- Iteracion con clientes reales.
+- No construir features sin data.
+- Comunicar sistema y logica, no solo interfaz.
+
+## Requisitos del contenido
+
+### P0
+
+- Reescribir la narrativa central para diferenciar Boreas de Relevo.
+- Reestructurar el homepage para que Relevo aparezca como el modulo actual dentro del sistema Boreas.
+- Reemplazar `mailto:` por un CTA transaccional real.
+- Mantener las tres verticales principales visibles: salud, belleza e inmobiliario.
+- Evitar promesas ambiguas que desborden el foco actual de conversion.
+
+### P1
+
+- Crear una seccion fuerte sobre playbooks por industria.
+- Usar esa seccion para compensar la dilution natural de trabajar tres verticales.
+- Hacer visible que la especializacion no vive en prompts sueltos sino en logica operacional.
+- Explicar el onboarding como una experiencia simple y confiable: el usuario aporta datos del negocio; Boreas/Relevo activan la estructura correcta.
+- Reforzar la confianza del usuario mostrando que no necesita diseñar la logica del sistema.
+
+### P2
+
+- Consolidar el contenido estrategico en una capa facil de iterar.
+- Mejorar SEO y metadata segun la nueva arquitectura de marca.
+- Preparar medicion y eventos para experimentar sobre CTA y captura.
+
+## Requisitos funcionales
+
+### CTA principal
+
+- El CTA debe dejar de depender de `mailto:`.
+- La solucion final queda abierta entre varias alternativas de alta conversion.
+- La seleccion de alternativa se hara en una exploracion posterior, no en este documento.
+- Si se usa formulario, debe:
+  - minimizar friccion,
+  - pedir solo lo necesario,
+  - aumentar la percepcion de valor,
+  - devolver algo util al usuario por completarlo.
+
+### Multi-vertical
+
+- La web debe sostener tres verticales sin parecer una solucion generica.
+- Cada vertical debe verse reflejada de forma creible.
+- El contenido debe demostrar adaptacion por playbook, no por cosmetica superficial.
+
+### Demo de producto
+
+- La demo debe representar a `Relevo`, no a Boreas como marca paraguas.
+- Debe mostrar calificacion, manejo de avance conversacional y empuje a accion.
+- Debe alinearse con la tesis de conversion y no solo con "responder mensajes".
+
+### Onboarding
+
+- Debe comunicar que el usuario no diseña la logica.
+- Debe mostrar que el sistema se configura a partir de:
+  - industria,
+  - informacion del negocio,
+  - precios,
+  - horarios,
+  - ubicacion,
+  - contexto operativo.
+- Debe aumentar confianza y reducir ansiedad de implementacion.
+
+## Requisitos de medicion
+
+Se debe preparar la base para medir:
+
+- click en CTA principal,
+- inicio de flujo de contacto,
+- finalizacion del flujo,
+- seleccion de vertical,
+- interacciones con demo,
+- scroll depth por seccion,
+- conversion a llamada o contacto efectivo.
+
+## No objetivos de v2.1
+
+- No lanzar aun modulos completos de adquisicion o retencion como propuesta principal del sitio.
+- No convertir la web en una app completa.
+- No sobrecargar el homepage con demasiados caminos secundarios.
+- No comprometer el mensaje principal por perseguir amplitud de features.
+
+## Riesgos
+
+- Trabajar tres verticales puede reducir claridad si la narrativa no es excepcionalmente precisa.
+- Elegir un CTA incorrecto puede aumentar friccion o bajar calidad del lead.
+- Si la seccion de playbooks no se explica bien, el mensaje puede seguir percibiendose como "otro chatbot".
+- Si onboarding no transmite control y simplicidad, la confianza puede caer.
+
+## Mitigaciones
+
+- Usar contenido explicativo fuerte para sostener las tres verticales.
+- Diseñar el CTA como experimento medible, no como decision cerrada por intuicion.
+- Tratar playbooks y onboarding como piezas de conversion, no como notas tecnicas.
+- Priorizar claridad semantica de marca por encima de copy creativo ambiguo.
+
+## Entregables esperados
+
+- Homepage v2.1 con nueva arquitectura narrativa.
+- PRD versionado dentro del repo.
+- Backlog en EPICs y subtasks `v2.1`.
+- Base de medicion para iteracion posterior.
+
+## Criterios de exito
+
+- Un usuario nuevo entiende en menos de un minuto que Boreas es la plataforma y Relevo el modulo actual.
+- Las tres verticales se sienten parte de una misma tesis operativa, no una lista dispersa.
+- El CTA principal deja de ser `mailto:` y pasa a un flujo medible.
+- El sitio comunica playbooks y onboarding como ventajas de conversion y confianza.
+- La version `2.1` queda documentada y ejecutable como roadmap real.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,45 @@
+export const BOREAS_ANALYTICS_EVENT = "boreas:analytics";
+export const BOREAS_ANALYTICS_QUEUE_KEY = "__BOREAS_ANALYTICS__";
+
+export type AnalyticsEventName = "cta_click" | "diagnostic_submit" | "diagnostic_result";
+
+export type AnalyticsMetaValue = string | number | boolean | null;
+
+export type AnalyticsEvent = {
+  name: AnalyticsEventName;
+  surface: string;
+  timestamp: string;
+  meta?: Record<string, AnalyticsMetaValue>;
+};
+
+declare global {
+  interface Window {
+    __BOREAS_ANALYTICS__?: AnalyticsEvent[];
+  }
+}
+
+export function createAnalyticsEvent(input: Omit<AnalyticsEvent, "timestamp">): AnalyticsEvent {
+  return {
+    ...input,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function trackAnalyticsEvent(input: Omit<AnalyticsEvent, "timestamp">): AnalyticsEvent | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const event = createAnalyticsEvent(input);
+  const queue = window[BOREAS_ANALYTICS_QUEUE_KEY] ?? [];
+
+  queue.push(event);
+  window[BOREAS_ANALYTICS_QUEUE_KEY] = queue;
+  window.dispatchEvent(new CustomEvent<AnalyticsEvent>(BOREAS_ANALYTICS_EVENT, { detail: event }));
+
+  if (process.env.NODE_ENV !== "production") {
+    console.info("[boreas:analytics]", event);
+  }
+
+  return event;
+}


### PR DESCRIPTION
## Summary
- Simplifies the homepage and diagnostic language so it reads more clearly for end users.
- Reworks the landing layout to use wider sections, a left/right hero composition, a persistent sticky header, and a new footer.
- Adds smoother navigation to the diagnostic section and normalizes Relevo entry points across the page.
- Refines the diagnostic flow, demo copy, and analytics surface to match the updated product story.

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`